### PR TITLE
feat(voice-notify): speak Stop and Notification events via macOS say

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -36,6 +36,12 @@
       "source": "./plugins/tempest",
       "description": "MCP server for accessing WeatherFlow Tempest personal weather station data",
       "category": "utilities"
+    },
+    {
+      "name": "voice-notify",
+      "source": "./plugins/voice-notify",
+      "description": "Speak Claude Code Stop and Notification events aloud via macOS say",
+      "category": "utilities"
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .DS_Store
 __pycache__/
 *.pyc
+
+# Superpowers brainstorming/planning docs — kept locally, not committed
+docs/superpowers/

--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ In Codex, install plugins from the `briandconnelly-plugins` marketplace after ad
 | [orb-cloud](plugins/orb-cloud/) | MCP server for managing Orb Cloud organizations and devices |
 | [orbnet](plugins/orbnet/) | MCP server for monitoring internet quality via Orb Local API |
 | [tempest](plugins/tempest/) | MCP server for accessing WeatherFlow Tempest personal weather station data |
+| [voice-notify](plugins/voice-notify/) | Speak Claude Code Stop and Notification events aloud via macOS say |

--- a/plugins/voice-notify/.claude-plugin/plugin.json
+++ b/plugins/voice-notify/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "voice-notify",
+  "description": "Speak Claude Code Stop and Notification events aloud via macOS say",
+  "version": "0.1.0",
+  "author": {
+    "name": "Brian Connelly"
+  },
+  "repository": "https://github.com/briandconnelly/briandconnelly-plugins",
+  "license": "MIT",
+  "keywords": ["notifications", "tts", "say", "macos", "hooks", "accessibility"],
+  "hooks": "./hooks/hooks.json"
+}

--- a/plugins/voice-notify/README.md
+++ b/plugins/voice-notify/README.md
@@ -1,0 +1,47 @@
+# voice-notify
+
+Speak Claude Code `Stop` and `Notification` events aloud through macOS `say`, so
+you can step away during long-running work and hear when Claude finishes or needs
+input.
+
+macOS-only.
+Silent until you opt in.
+
+## Requirements
+
+- macOS (uses the built-in `say` command).
+- [`jq`](https://jqlang.github.io/jq/) — install with `brew install jq`.
+
+## Opt in
+
+The plugin stays silent until you enable it, one of two ways:
+
+- **Per project:** create an empty `.claude-voice` file in the project root.
+- **Per session:** start Claude with `CLAUDE_VOICE=1 claude`.
+
+## Tuning
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `CLAUDE_VOICE_NAME` | `Samantha` | Any installed `say` voice (see `say -v '?'`). |
+| `CLAUDE_VOICE_RATE` | `200` | Speech rate in words per minute. |
+
+## What it says
+
+- **Stop:** `"<session> done. <first sentence of Claude's last message>"`
+- **Notification:** `"<session> <notification message>"`
+
+The `<session>` label is your tmux session name if present, otherwise the project
+directory's name.
+
+## Behavior notes
+
+It never blocks Claude (speech is launched detached) and never reports errors back
+to the agent. If you have opted in but `jq` is missing or the hook payload cannot
+be parsed, it prints a one-line note to stderr and exits cleanly.
+
+## Tests
+
+```bash
+bash tests/run-tests.sh
+```

--- a/plugins/voice-notify/hooks/hooks.json
+++ b/plugins/voice-notify/hooks/hooks.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/voice-notify.sh\"" }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/voice-notify.sh\"" }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/voice-notify/hooks/voice-notify.sh
+++ b/plugins/voice-notify/hooks/voice-notify.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# voice-notify.sh — speak Claude Code Stop / Notification events via macOS `say`.
+#
+# Opt-in (stays silent otherwise):
+#   • per-project : create a `.claude-voice` file in the project root
+#   • per-session : launch with `CLAUDE_VOICE=1 claude`
+#
+# Optional tuning (env vars):
+#   CLAUDE_VOICE_NAME   say voice            (default: Samantha)
+#   CLAUDE_VOICE_RATE   words per minute     (default: 200)
+#
+# Requires: jq. macOS-only (silently inert elsewhere).
+#
+# Error routing: this hook never exits 2 and never writes to the agent channel.
+# Expected-inert conditions exit 0 silently; genuine problems for an opted-in
+# user print one line to stderr and still exit 0.
+
+set -uo pipefail
+
+# ---- macOS guard: silently inert when `say` is unavailable -----------------
+command -v say >/dev/null 2>&1 || exit 0
+
+payload="$(cat)"
+
+# ---- opt-in gate -----------------------------------------------------------
+# Opt in with exactly CLAUDE_VOICE=1 (so CLAUDE_VOICE=0 stays OFF) or a
+# `.claude-voice` file in the project root.
+proj="${CLAUDE_PROJECT_DIR:-$PWD}"
+if [[ "${CLAUDE_VOICE:-}" != "1" && ! -e "$proj/.claude-voice" ]]; then
+  exit 0
+fi
+
+# ---- jq guard: real misconfig for an opted-in user -> stderr, exit 0 -------
+command -v jq >/dev/null 2>&1 || {
+  echo "voice-notify: jq not found; install with 'brew install jq'" >&2
+  exit 0
+}
+
+voice="${CLAUDE_VOICE_NAME:-Samantha}"
+rate="${CLAUDE_VOICE_RATE:-200}"
+
+event="$(printf '%s' "$payload" | jq -r '.hook_event_name // empty' 2>/dev/null)"
+
+# ---- unparseable / missing event -> diagnostic, no speech ------------------
+if [[ -z "$event" ]]; then
+  echo "voice-notify: could not parse hook_event_name from payload" >&2
+  exit 0
+fi
+
+# ---- session label: tmux session -> project dir name -> "Claude" -----------
+session=""
+if [[ -n "${TMUX_PANE:-}" ]] && command -v tmux >/dev/null 2>&1; then
+  session="$(tmux display-message -p -t "$TMUX_PANE" '#S' 2>/dev/null || true)"
+fi
+[[ -z "$session" ]] && session="$(basename "$proj")"
+[[ -z "$session" ]] && session="Claude"
+
+# ---- build the spoken line -------------------------------------------------
+case "$event" in
+  Stop)
+    msg="$(printf '%s' "$payload" | jq -r '.last_assistant_message // empty' 2>/dev/null)"
+    # collapse to one line, take the first sentence, cap length
+    summary="$(printf '%s' "$msg" | tr '\n' ' ' | sed -E 's/([.!?]).*/\1/' | cut -c1-160)"
+    [[ -z "$summary" ]] && summary="finished."
+    spoken="$session done. $summary"
+    ;;
+  Notification)
+    # `// empty` + bash fallback so an empty-string message also falls back
+    # (jq's `//` only substitutes for null/absent, not "").
+    note="$(printf '%s' "$payload" | jq -r '.message // empty' 2>/dev/null)"
+    [[ -z "$note" ]] && note="needs your input"
+    spoken="$session $note"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+# ---- speak without blocking Claude ----------------------------------------
+nohup say -v "$voice" -r "$rate" "$spoken" >/dev/null 2>&1 &
+exit 0

--- a/plugins/voice-notify/tests/run-tests.sh
+++ b/plugins/voice-notify/tests/run-tests.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Self-contained tests for hooks/voice-notify.sh — no external framework.
+# Isolates PATH to a bin dir of symlinks to the real tools the script needs,
+# so individual cases can omit `say` or `jq` to simulate their absence.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../hooks/voice-notify.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+# Real tools the script may call (besides bash builtins), plus `bash` itself —
+# cases run `PATH="$bin" bash "$SCRIPT"`, so `bash` must resolve under the
+# isolated PATH. `say`/`jq` are added per-case so we can simulate their absence;
+# `tmux` is intentionally omitted so the session label falls back to the
+# project-dir basename.
+REAL_TOOLS=(bash cat jq basename tr sed cut nohup)
+
+# make_bin <dir> <tool...> — symlink the named real tools into an isolated dir.
+make_bin() {
+  local dir="$1"; shift
+  rm -rf "$dir"; mkdir -p "$dir"
+  local t path
+  for t in "$@"; do
+    path="$(command -v "$t" 2>/dev/null || true)"
+    [[ -n "$path" ]] && ln -sf "$path" "$dir/$t"
+  done
+}
+
+# install_say_stub <dir> <log> — a `say` that records each argv on its own line.
+install_say_stub() {
+  local dir="$1" log="$2"
+  cat >"$dir/say" <<EOF
+#!/bin/bash
+printf '%s\n' "\$@" >>"$log"
+EOF
+  chmod +x "$dir/say"
+}
+
+# wait_for_file <path> — poll briefly; the script backgrounds say via nohup &.
+wait_for_file() {
+  local i=0
+  while [[ ! -s "$1" && $i -lt 80 ]]; do sleep 0.05; i=$((i+1)); done
+}
+
+ok()   { echo "ok   - $1"; pass=$((pass+1)); }
+bad()  { echo "FAIL - $1"; fail=$((fail+1)); }
+
+# ---- Case 1: not opted in -> silent, no say -------------------------------
+case_not_opted_in() {
+  local name="not opted in -> silent"
+  local bin="$WORK/bin1" log="$WORK/say1.log" proj="$WORK/proj1"
+  mkdir -p "$proj"; make_bin "$bin" "${REAL_TOOLS[@]}"; install_say_stub "$bin" "$log"
+  local out
+  out="$(unset CLAUDE_VOICE; CLAUDE_PROJECT_DIR="$proj" PATH="$bin" \
+    bash "$SCRIPT" <<<'{"hook_event_name":"Stop","last_assistant_message":"Hi."}' 2>&1)"
+  sleep 0.2
+  [[ ! -s "$log" && -z "$out" ]] && ok "$name" || bad "$name"
+}
+
+# ---- Case 2: opted in + Stop -> "<session> done. <summary>" ----------------
+case_stop() {
+  local name="Stop -> session done. summary"
+  local bin="$WORK/bin2" log="$WORK/say2.log" proj="$WORK/voice-notify-test-proj"
+  mkdir -p "$proj"; make_bin "$bin" "${REAL_TOOLS[@]}"; install_say_stub "$bin" "$log"
+  CLAUDE_VOICE=1 CLAUDE_PROJECT_DIR="$proj" PATH="$bin" \
+    bash "$SCRIPT" <<<'{"hook_event_name":"Stop","last_assistant_message":"Build complete. More details follow."}'
+  wait_for_file "$log"
+  grep -Fxq "voice-notify-test-proj done. Build complete." "$log" && ok "$name" || bad "$name"
+}
+
+# ---- Case 3: opted in + Notification -> "<session> <message>" --------------
+case_notification() {
+  local name="Notification -> session message"
+  local bin="$WORK/bin3" log="$WORK/say3.log" proj="$WORK/voice-notify-test-proj"
+  mkdir -p "$proj"; make_bin "$bin" "${REAL_TOOLS[@]}"; install_say_stub "$bin" "$log"
+  CLAUDE_VOICE=1 CLAUDE_PROJECT_DIR="$proj" PATH="$bin" \
+    bash "$SCRIPT" <<<'{"hook_event_name":"Notification","message":"needs your permission"}'
+  wait_for_file "$log"
+  grep -Fxq "voice-notify-test-proj needs your permission" "$log" && ok "$name" || bad "$name"
+}
+
+# ---- Case 4: voice/rate env vars passed through to say ---------------------
+case_voice_rate() {
+  local name="CLAUDE_VOICE_NAME / _RATE passed to say"
+  local bin="$WORK/bin4" log="$WORK/say4.log" proj="$WORK/voice-notify-test-proj"
+  mkdir -p "$proj"; make_bin "$bin" "${REAL_TOOLS[@]}"; install_say_stub "$bin" "$log"
+  CLAUDE_VOICE=1 CLAUDE_VOICE_NAME=Alex CLAUDE_VOICE_RATE=180 \
+    CLAUDE_PROJECT_DIR="$proj" PATH="$bin" \
+    bash "$SCRIPT" <<<'{"hook_event_name":"Stop","last_assistant_message":"Done."}'
+  wait_for_file "$log"
+  grep -Fxq "Alex" "$log" && grep -Fxq "180" "$log" && ok "$name" || bad "$name"
+}
+
+# ---- Case 5: malformed JSON + opted in -> stderr note, no say --------------
+case_malformed() {
+  local name="malformed JSON -> stderr note, no say"
+  local bin="$WORK/bin5" log="$WORK/say5.log" proj="$WORK/proj5"
+  mkdir -p "$proj"; make_bin "$bin" "${REAL_TOOLS[@]}"; install_say_stub "$bin" "$log"
+  local err
+  err="$(CLAUDE_VOICE=1 CLAUDE_PROJECT_DIR="$proj" PATH="$bin" \
+    bash "$SCRIPT" <<<'{not valid json' 2>&1 >/dev/null)"
+  sleep 0.2
+  [[ ! -s "$log" ]] && [[ "$err" == *"could not parse"* ]] && ok "$name" || bad "$name"
+}
+
+# ---- Case 6: jq absent + opted in -> stderr note, no say -------------------
+case_no_jq() {
+  local name="jq absent -> stderr note, no say"
+  local bin="$WORK/bin6" log="$WORK/say6.log" proj="$WORK/proj6"
+  mkdir -p "$proj"
+  make_bin "$bin" bash cat basename tr sed cut nohup   # deliberately no jq
+  install_say_stub "$bin" "$log"
+  local err
+  err="$(CLAUDE_VOICE=1 CLAUDE_PROJECT_DIR="$proj" PATH="$bin" \
+    bash "$SCRIPT" <<<'{"hook_event_name":"Stop","last_assistant_message":"Hi."}' 2>&1 >/dev/null)"
+  sleep 0.2
+  [[ ! -s "$log" ]] && [[ "$err" == *"jq not found"* ]] && ok "$name" || bad "$name"
+}
+
+# ---- Case 7: say absent (non-macOS) -> silent, no stderr -------------------
+case_no_say() {
+  local name="say absent -> silent exit 0"
+  local bin="$WORK/bin7" proj="$WORK/proj7"
+  mkdir -p "$proj"
+  make_bin "$bin" "${REAL_TOOLS[@]}"   # no say stub installed
+  local out
+  out="$(CLAUDE_VOICE=1 CLAUDE_PROJECT_DIR="$proj" PATH="$bin" \
+    bash "$SCRIPT" <<<'{"hook_event_name":"Stop","last_assistant_message":"Hi."}' 2>&1)"
+  [[ -z "$out" ]] && ok "$name" || bad "$name"
+}
+
+# ---- Case 8: plugin path containing a space -> still runs ------------------
+case_spaced_path() {
+  local name="spaced plugin path -> still speaks"
+  local bin="$WORK/bin8" log="$WORK/say8.log" proj="$WORK/voice-notify-test-proj"
+  local spaced="$WORK/with space/hooks"
+  mkdir -p "$proj" "$spaced"; cp "$SCRIPT" "$spaced/voice-notify.sh"
+  make_bin "$bin" "${REAL_TOOLS[@]}"; install_say_stub "$bin" "$log"
+  CLAUDE_VOICE=1 CLAUDE_PROJECT_DIR="$proj" PATH="$bin" \
+    bash "$spaced/voice-notify.sh" <<<'{"hook_event_name":"Stop","last_assistant_message":"Done."}'
+  wait_for_file "$log"
+  grep -Fxq "voice-notify-test-proj done. Done." "$log" && ok "$name" || bad "$name"
+}
+
+# ---- Case 9: CLAUDE_VOICE=0 stays OFF -> silent, no say --------------------
+case_voice_zero() {
+  local name="CLAUDE_VOICE=0 -> silent"
+  local bin="$WORK/bin9" log="$WORK/say9.log" proj="$WORK/proj9"
+  mkdir -p "$proj"; make_bin "$bin" "${REAL_TOOLS[@]}"; install_say_stub "$bin" "$log"
+  local out
+  out="$(CLAUDE_VOICE=0 CLAUDE_PROJECT_DIR="$proj" PATH="$bin" \
+    bash "$SCRIPT" <<<'{"hook_event_name":"Stop","last_assistant_message":"Hi."}' 2>&1)"
+  sleep 0.2
+  [[ ! -s "$log" && -z "$out" ]] && ok "$name" || bad "$name"
+}
+
+# ---- Case 10: empty Notification message -> fallback text ------------------
+case_empty_message() {
+  local name="empty Notification message -> fallback"
+  local bin="$WORK/bin10" log="$WORK/say10.log" proj="$WORK/voice-notify-test-proj"
+  mkdir -p "$proj"; make_bin "$bin" "${REAL_TOOLS[@]}"; install_say_stub "$bin" "$log"
+  CLAUDE_VOICE=1 CLAUDE_PROJECT_DIR="$proj" PATH="$bin" \
+    bash "$SCRIPT" <<<'{"hook_event_name":"Notification","message":""}'
+  wait_for_file "$log"
+  grep -Fxq "voice-notify-test-proj needs your input" "$log" && ok "$name" || bad "$name"
+}
+
+# ---- Case 11: .claude-voice file opt-in (no env var) -> speaks -------------
+case_file_optin() {
+  local name=".claude-voice file opt-in -> speaks"
+  local bin="$WORK/bin11" log="$WORK/say11.log" proj="$WORK/voice-notify-test-proj"
+  mkdir -p "$proj"; touch "$proj/.claude-voice"
+  make_bin "$bin" "${REAL_TOOLS[@]}"; install_say_stub "$bin" "$log"
+  ( unset CLAUDE_VOICE; CLAUDE_PROJECT_DIR="$proj" PATH="$bin" \
+    bash "$SCRIPT" <<<'{"hook_event_name":"Stop","last_assistant_message":"All set."}' )
+  wait_for_file "$log"
+  grep -Fxq "voice-notify-test-proj done. All set." "$log" && ok "$name" || bad "$name"
+}
+
+case_not_opted_in
+case_stop
+case_notification
+case_voice_rate
+case_malformed
+case_no_jq
+case_no_say
+case_spaced_path
+case_voice_zero
+case_empty_message
+case_file_optin
+
+echo "-----"
+echo "passed: $pass  failed: $fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
## Summary

Adds **voice-notify**, the marketplace's first hooks-only plugin. It speaks Claude Code `Stop` and `Notification` hook events aloud via macOS `say`, so you can step away during long-running work and hear when Claude finishes or needs input.

- **Opt-in, silent by default** — speaks only when `CLAUDE_VOICE=1` (exactly) or a `.claude-voice` file exists in the project root.
- **macOS-only** — inert (silent `exit 0`) when `say` is unavailable.
- **Never blocks Claude, never talks to the agent** — speech is launched detached (`nohup … &`); the hook never exits `2`. Genuine problems for an opted-in user (missing `jq`, unparseable payload) go to stderr + `exit 0`, visible to the user but not the agent.
- **Tuning** via `CLAUDE_VOICE_NAME` (default `Samantha`) and `CLAUDE_VOICE_RATE` (default `200`).
- Registered in `.claude-plugin/marketplace.json` and the root README. No Codex manifest — hooks are Claude Code-specific.
- Also gitignores local `docs/superpowers/` planning docs.

### Files
- `plugins/voice-notify/.claude-plugin/plugin.json` — manifest
- `plugins/voice-notify/hooks/hooks.json` — registers Stop + Notification command hooks
- `plugins/voice-notify/hooks/voice-notify.sh` — the speaking script
- `plugins/voice-notify/tests/run-tests.sh` — 11-case self-contained bash test harness
- `plugins/voice-notify/README.md`

## Test Plan
- [x] `bash plugins/voice-notify/tests/run-tests.sh` → `passed: 11  failed: 0` (covers opt-in gating, both opt-in mechanisms, Stop/Notification formatting, voice/rate passthrough, malformed JSON, missing `jq`, missing `say`, `CLAUDE_VOICE=0` stays off, empty-message fallback, spaced install path)
- [ ] Install locally on macOS, set `CLAUDE_VOICE=1`, confirm speech on Stop and Notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)