### PR TITLE
fix: remove redundant hooks reference from voice-notify manifest

### DIFF
--- a/plugins/voice-notify/.claude-plugin/plugin.json
+++ b/plugins/voice-notify/.claude-plugin/plugin.json
@@ -1,12 +1,11 @@
 {
   "name": "voice-notify",
   "description": "Speak Claude Code Stop and Notification events aloud via macOS say",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Brian Connelly"
   },
   "repository": "https://github.com/briandconnelly/briandconnelly-plugins",
   "license": "MIT",
-  "keywords": ["notifications", "tts", "say", "macos", "hooks", "accessibility"],
-  "hooks": "./hooks/hooks.json"
+  "keywords": ["notifications", "tts", "say", "macos", "hooks", "accessibility"]
 }


### PR DESCRIPTION
## Context

Installing the `voice-notify` plugin produced a duplicate-hooks error:

```
Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded file
.../voice-notify/0.1.0/hooks/hooks.json.
The standard hooks/hooks.json is loaded automatically, so manifest.hooks should only
reference additional hook files.
```

Claude Code automatically loads the standard `hooks/hooks.json`. The manifest's explicit `"hooks": "./hooks/hooks.json"` pointed at that same file, so it was loaded twice.

## Change

- Remove the redundant `"hooks"` key from `plugins/voice-notify/.claude-plugin/plugin.json`.
- Bump version `0.1.0` → `0.1.1`.

The `hooks/hooks.json` file itself is unchanged and correct — it still registers the Stop and Notification hooks, now loaded once via the standard path.

## Verified

- `python3 -m json.tool` confirms the manifest is still valid JSON.
- Confirmed `voice-notify` was the only plugin in the repo carrying this redundant `"hooks"` reference (`grep -rln '"hooks":' plugins/*/.claude-plugin/plugin.json`).
- Manually patched my local plugin cache the same way and confirmed the error no longer appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)