### PR TITLE
feat(cc-plugin-codex): readiness probes, effort control, --no-chrome, and background review jobs

### DIFF
--- a/plugins/cc-plugin-codex/README.md
+++ b/plugins/cc-plugin-codex/README.md
@@ -116,8 +116,9 @@ to that workspace's state directory can read or cancel its jobs.
 Each paid tool accepts `effort` (`low|medium|high|xhigh|max`), passed through to the
 `claude` CLI's `--effort`. It defaults to `xhigh` — review depth is the whole point of
 this server. Lower it (`high`/`medium`) to trade rigor for cost on routine reviews, or
-set the default with `CC_PLUGIN_CODEX_EFFORT`. An unrecognized value falls back to the
-default rather than failing the call.
+set the default with `CC_PLUGIN_CODEX_EFFORT`. An invalid per-call `effort` is a typed
+enum, so it is rejected as a schema validation error before the tool runs; an
+unrecognized `CC_PLUGIN_CODEX_EFFORT` env value instead falls back to the default.
 
 ## Environment variables
 

--- a/plugins/cc-plugin-codex/README.md
+++ b/plugins/cc-plugin-codex/README.md
@@ -25,9 +25,13 @@ The paid tools (`claude_ask`, `claude_review_changes`, `claude_adversarial_revie
 **block synchronously** for up to `timeout_seconds` (default 180s, max 600s).
 They can be **cancelled** by the client, which terminates the underlying Claude process, but not resumed.
 Call `claude_status` first — it is
-free and reports the resolved defaults (`config_mode`, `access`, `model`, clamped
-`max_budget_usd`/`timeout_seconds`, and the clamp bounds) a no-argument paid call
+free and reports the resolved defaults (`config_mode`, `access`, `model`, `effort`,
+clamped `max_budget_usd`/`timeout_seconds`, and the clamp bounds) a no-argument paid call
 would use, so you can predict cost and behavior before spending.
+It also runs free readiness probes — `claude_authenticated` (so you can catch a
+logged-out CLI before paying for a call that would only then fail auth),
+`version_supported` (whether the installed CLI matches the supported major), and a
+combined `ready` flag.
 Every paid result also reports `meta.cost_usd` and `meta.usage` (token counts) so an
 agent can track actual spend across calls.
 
@@ -56,7 +60,7 @@ This v1 runs from the local checkout (not yet published to PyPI).
 | `scoped` | drops user-global settings + user MCP servers; keeps CLAUDE.md | your existing login |
 | `bare` | strips CLAUDE.md/memory/hooks | requires `ANTHROPIC_API_KEY` |
 
-Known limitation: in `claude 2.1.161` there is no OAuth-preserving way to fully strip
+Known limitation: in `claude 2.1.x` there is no OAuth-preserving way to fully strip
 `CLAUDE.md`/memory — full independence (`bare`) requires an API key.
 
 ## Access modes (`access`)
@@ -86,7 +90,16 @@ plugin install) so reviews target your project rather than the plugin checkout.
   user-level Claude hooks and settings; use `config_mode=bare` for full isolation.
 - Each call is paid and sends code to Anthropic; the server caps cost and time per call.
 
+## Reasoning effort (`effort`)
+
+Each paid tool accepts `effort` (`low|medium|high|xhigh|max`), passed through to the
+`claude` CLI's `--effort`. It defaults to `xhigh` — review depth is the whole point of
+this server. Lower it (`high`/`medium`) to trade rigor for cost on routine reviews, or
+set the default with `CC_PLUGIN_CODEX_EFFORT`. An unrecognized value falls back to the
+default rather than failing the call.
+
 ## Environment variables
 
 `CC_PLUGIN_CODEX_CLAUDE_CONFIG`, `CC_PLUGIN_CODEX_ACCESS`, `CC_PLUGIN_CODEX_MODEL`,
-`CC_PLUGIN_CODEX_MAX_BUDGET_USD`, `CC_PLUGIN_CODEX_TIMEOUT_SECONDS`, `ANTHROPIC_API_KEY`.
+`CC_PLUGIN_CODEX_EFFORT`, `CC_PLUGIN_CODEX_MAX_BUDGET_USD`,
+`CC_PLUGIN_CODEX_TIMEOUT_SECONDS`, `ANTHROPIC_API_KEY`.

--- a/plugins/cc-plugin-codex/README.md
+++ b/plugins/cc-plugin-codex/README.md
@@ -4,13 +4,14 @@ Call Claude Code from Codex for bounded, independent code review and second opin
 The mirror image of [`openai/codex-plugin-cc`](https://github.com/openai/codex-plugin-cc)'s
 review surface.
 Unlike that plugin, cc-plugin-codex is review-only: it does not delegate write-capable
-tasks or run background jobs.
+tasks. Reviews can run synchronously or as background jobs, but Claude only ever reviews.
 
 ## What it does
 
-An MCP server wraps the `claude` CLI and exposes four read-only tools to Codex:
-`claude_ask`, `claude_review_changes`, `claude_adversarial_review`, `claude_status`.
-Claude reviews; it never edits your code.
+An MCP server wraps the `claude` CLI and exposes read-only tools to Codex:
+`claude_ask`, `claude_review_changes`, `claude_adversarial_review`, and `claude_status`,
+plus `claude_review_changes_async` with `claude_job_status`/`claude_job_result`/
+`claude_job_cancel` for background reviews. Claude reviews; it never edits your code.
 
 Each tool publishes an output schema describing the `ok`-discriminated result
 (`{"ok": true, ...}` on success, `{"ok": false, "error": {code, message, repair}, ...}`
@@ -90,6 +91,26 @@ plugin install) so reviews target your project rather than the plugin checkout.
   user-level Claude hooks and settings; use `config_mode=bare` for full isolation.
 - Each call is paid and sends code to Anthropic; the server caps cost and time per call.
 
+## Background reviews
+
+`claude_review_changes_async` launches a diff review as a detached job and returns a
+handle `{ok, job_id, status:"running", …}` immediately instead of blocking the Codex
+turn. Poll `claude_job_status(job_id)`, then call `claude_job_result(job_id)` once
+`result_available` is true — the result is the **same** `ok`/`verdict`/`findings`
+envelope the synchronous tool returns, with `meta.job_id` set. `claude_job_cancel`
+terminates a running job. The status/result/cancel tools are free.
+
+The diff is gathered at launch (same secret redaction and `--max-budget-usd` cap as the
+sync path). Because the server drives one-shot `claude -p --output-format json`, a job's
+completion is simply "the process exited and wrote its JSON envelope" — no interactive
+log scraping. State lives on disk keyed by workspace, so status/result/cancel survive an
+MCP server restart. There is no daemon: overrunning jobs are stopped on the next status
+poll (deadline `CC_PLUGIN_CODEX_JOB_MAX_SECONDS`, default 1800s), records are cleaned up
+after `CC_PLUGIN_CODEX_JOB_TTL` (default 24h), and the budget cap bounds spend even for a
+job nobody polls. Job records (which contain the diff) are stored under
+`CC_PLUGIN_CODEX_STATE_DIR` (default `~/.cache/cc-plugin-codex/jobs`); anyone with access
+to that workspace's state directory can read or cancel its jobs.
+
 ## Reasoning effort (`effort`)
 
 Each paid tool accepts `effort` (`low|medium|high|xhigh|max`), passed through to the
@@ -103,3 +124,6 @@ default rather than failing the call.
 `CC_PLUGIN_CODEX_CLAUDE_CONFIG`, `CC_PLUGIN_CODEX_ACCESS`, `CC_PLUGIN_CODEX_MODEL`,
 `CC_PLUGIN_CODEX_EFFORT`, `CC_PLUGIN_CODEX_MAX_BUDGET_USD`,
 `CC_PLUGIN_CODEX_TIMEOUT_SECONDS`, `ANTHROPIC_API_KEY`.
+
+Background jobs add: `CC_PLUGIN_CODEX_STATE_DIR`, `CC_PLUGIN_CODEX_JOB_MAX_SECONDS`,
+`CC_PLUGIN_CODEX_JOB_TTL`, `CC_PLUGIN_CODEX_JOB_MAX_COUNT`.

--- a/plugins/cc-plugin-codex/skills/collaborating-with-claude/SKILL.md
+++ b/plugins/cc-plugin-codex/skills/collaborating-with-claude/SKILL.md
@@ -22,6 +22,7 @@ Do NOT call Claude in a loop, and never call Claude just because Claude suggeste
 
 - `claude_ask` — a free-form second opinion or recommendation.
 - `claude_review_changes` — Claude reviews your git diff (`scope` = working_tree | staged | branch).
+- `claude_review_changes_async` — same review as a background job for large diffs or when you want to keep working; returns a `job_id`. Poll `claude_job_status`, then `claude_job_result` (same envelope as the sync tool); `claude_job_cancel` to stop it.
 - `claude_adversarial_review` — Claude attacks a plan/claim and lists the strongest counterarguments.
 - `claude_status` — free readiness check: reports whether `claude` is installed, authenticated (`claude_authenticated`), version-compatible (`version_supported`), and overall `ready`, plus the resolved defaults a no-arg call would use. Run it first if a call fails, or to confirm readiness before spending.
 

--- a/plugins/cc-plugin-codex/skills/collaborating-with-claude/SKILL.md
+++ b/plugins/cc-plugin-codex/skills/collaborating-with-claude/SKILL.md
@@ -23,7 +23,7 @@ Do NOT call Claude in a loop, and never call Claude just because Claude suggeste
 - `claude_ask` — a free-form second opinion or recommendation.
 - `claude_review_changes` — Claude reviews your git diff (`scope` = working_tree | staged | branch).
 - `claude_adversarial_review` — Claude attacks a plan/claim and lists the strongest counterarguments.
-- `claude_status` — check that `claude` is installed and authenticated (free; run this first if a call fails).
+- `claude_status` — free readiness check: reports whether `claude` is installed, authenticated (`claude_authenticated`), version-compatible (`version_supported`), and overall `ready`, plus the resolved defaults a no-arg call would use. Run it first if a call fails, or to confirm readiness before spending.
 
 ## Reading results
 
@@ -38,3 +38,4 @@ Do NOT call Claude in a loop, and never call Claude just because Claude suggeste
 - The server never sends `.env`/secret files; redaction is filename-based, not content-scanning, so do not paste secrets into prompts and do not rely on it to catch secrets hardcoded inside ordinary source files.
 - Default access is `toolless` (Claude gets no tools) and `config_mode=inherit`; both access modes are read-only (Claude never gets write/Bash). Use `config_mode=bare` only when you want a fully independent reviewer and have `ANTHROPIC_API_KEY` set.
 - Cap cost/time with `max_budget_usd` and `timeout_seconds` for large reviews.
+- Reviews run at `effort=xhigh` by default for depth. Lower `effort` to `high`/`medium` to save cost on routine changes; raise to `max` for the most subtle ones.

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/claude.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/claude.py
@@ -27,16 +27,36 @@ class ClaudeRun:
 
 
 def build_command(prompt: str, config_mode: str, access: str, model: str | None,
-                  max_budget_usd: float) -> list[str]:
-    cmd = ["claude", "-p", "--output-format", "json"]
+                  max_budget_usd: float, effort: str | None = None) -> list[str]:
+    # --no-chrome disables the "Claude in Chrome" integration, which could
+    # otherwise open an interactive picker that hangs an unattended run until the
+    # timeout (burning the whole timeout and the spend) instead of answering.
+    cmd = ["claude", "-p", "--output-format", "json", "--no-chrome"]
     cmd += config_mode_flags(config_mode)
     cmd += access_flags(access)
     cmd += ["--append-system-prompt", INDEPENDENT_CRITIC_PROMPT]
     cmd += ["--max-budget-usd", f"{max_budget_usd}"]
+    if effort:
+        cmd += ["--effort", effort]
     if model:
         cmd += ["--model", model]
     cmd += ["--", prompt]  # end-of-options separator, then the prompt as positional
     return cmd
+
+
+def auth_status(timeout_seconds: int = 10) -> tuple[bool | None, str | None]:
+    """Probe `claude auth status` without making a paid call.
+
+    Returns (logged_in, detail). logged_in is None when the probe could not run
+    (claude missing, timeout) so callers can report 'unknown' rather than a
+    misleading False."""
+    try:
+        proc = subprocess.run(["claude", "auth", "status", "--text"],
+                              capture_output=True, text=True, timeout=timeout_seconds)
+    except (OSError, subprocess.SubprocessError):
+        return None, None
+    detail = (proc.stdout or proc.stderr).strip() or None
+    return proc.returncode == 0, detail
 
 
 def _kill_process_tree(proc: subprocess.Popen) -> None:

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/config.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/config.py
@@ -3,12 +3,24 @@
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass
 
 EMPTY_MCP = '{"mcpServers":{}}'
 
 MIN_BUDGET_USD, MAX_BUDGET_USD = 0.01, 5.00
 MIN_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS = 10, 600
+
+# Reasoning effort levels the `claude` CLI accepts for `--effort`. We default to
+# a high level because the whole value of this server is review depth; lower it
+# per-call (or via CC_PLUGIN_CODEX_EFFORT) to trade rigor for cost on routine work.
+VALID_EFFORTS = ("low", "medium", "high", "xhigh", "max")
+DEFAULT_EFFORT = "xhigh"
+
+# Major version of the `claude` CLI this server is built against. claude_status
+# reports whether the installed CLI matches, so a future breaking change in the
+# CLI contract is visible for free instead of only surfacing mid paid call.
+SUPPORTED_MAJOR = 2
 
 INDEPENDENT_CRITIC_PROMPT = (
     "You are being asked for an independent critique of Codex's work.\n"
@@ -34,6 +46,7 @@ class Defaults:
     model: str | None
     max_budget_usd: float
     timeout_seconds: int
+    effort: str
 
 
 def _env_float(name: str, default: float) -> float:
@@ -63,7 +76,28 @@ def defaults() -> Defaults:
         model=os.environ.get("CC_PLUGIN_CODEX_MODEL") or None,
         max_budget_usd=_env_float("CC_PLUGIN_CODEX_MAX_BUDGET_USD", 1.00),
         timeout_seconds=_env_int("CC_PLUGIN_CODEX_TIMEOUT_SECONDS", 180),
+        effort=sanitize_effort(os.environ.get("CC_PLUGIN_CODEX_EFFORT")),
     )
+
+
+def sanitize_effort(value: str | None) -> str:
+    """Normalize an effort value to a CLI-accepted level, falling back to the
+    default. An invalid env value must not break a paid call, so it degrades
+    rather than raising."""
+    return value if value in VALID_EFFORTS else DEFAULT_EFFORT
+
+
+def version_supported(version: str | None) -> bool | None:
+    """Whether the installed `claude --version` string matches SUPPORTED_MAJOR.
+
+    Returns None when the version is unknown/unparseable (so callers can report
+    'unknown' rather than a false 'unsupported')."""
+    if not version:
+        return None
+    match = re.search(r"(\d+)\.\d+\.\d+", version)
+    if not match:
+        return None
+    return int(match.group(1)) == SUPPORTED_MAJOR
 
 
 def clamp_budget(value: float) -> float:

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/jobs.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/jobs.py
@@ -27,7 +27,7 @@ from typing import Optional
 from uuid import uuid4
 
 from cc_plugin_codex.normalize import apply_cost_usage, normalize_envelope
-from cc_plugin_codex.schemas import ContextSummary, Meta
+from cc_plugin_codex.schemas import FINGERPRINT, ContextSummary, Meta
 
 STATE_ENV = "CC_PLUGIN_CODEX_STATE_DIR"
 TTL_ENV = "CC_PLUGIN_CODEX_JOB_TTL"
@@ -38,7 +38,7 @@ DEFAULT_TTL = 86_400          # delete terminal job records after 24h
 DEFAULT_MAX_SECONDS = 1_800   # wall-clock cap; a poll past this reaps the job
 DEFAULT_MAX_COUNT = 50        # retained jobs per workspace; evict oldest terminal
 
-_TERMINAL = {"done", "failed", "cancelled", "timeout", "expired"}
+_TERMINAL = {"done", "failed", "cancelled", "timeout"}
 
 
 def _int_env(name: str, default: int) -> int:
@@ -229,6 +229,16 @@ def _elapsed_ms(meta: dict) -> int:
     return max(0, int((end - meta.get("started_epoch", end)) * 1000))
 
 
+def _deadline_seconds(meta: dict) -> int:
+    """The wall-clock window the job was STARTED with (deadline minus start), not
+    the current env value — so status stays consistent if the env later changes."""
+    started = meta.get("started_epoch")
+    deadline = meta.get("deadline_epoch")
+    if started is not None and deadline is not None:
+        return max(0, int(round(deadline - started)))
+    return max_seconds()
+
+
 def _reap_workspace(cwd: str) -> None:
     """Lazy maintenance: refresh statuses and delete expired terminal records."""
     ws = _ws_dir(cwd)
@@ -310,9 +320,10 @@ def status(cwd: str, job_id: str) -> Optional[dict]:
         "ok": True, "job_id": job_id, "kind": meta.get("kind", ""),
         "status": state, "started_at": meta.get("started_at", ""),
         "elapsed_ms": _elapsed_ms(meta),
-        "deadline_seconds": max_seconds(),
+        "deadline_seconds": _deadline_seconds(meta),
         "result_available": state == "done",
         "cost_usd": cost, "detail": detail,
+        "fingerprint": FINGERPRINT,
     }
 
 
@@ -357,8 +368,6 @@ _STATE_TO_ERROR = {
                   "Start a new job; a cancelled run cannot be resumed."),
     "timeout": ("job_timeout", "The job exceeded its wall-clock deadline and was stopped.",
                 "Narrow the scope or raise CC_PLUGIN_CODEX_JOB_MAX_SECONDS, then start a new job."),
-    "expired": ("job_failed", "The job record expired and was cleaned up.",
-                "Start a new job."),
 }
 
 

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/jobs.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/jobs.py
@@ -1,0 +1,402 @@
+"""Detached background jobs for long Claude reviews.
+
+This server drives a one-shot ``claude -p --output-format json`` call, so a job's
+terminal output is a single JSON envelope written to ``result.json`` — completion
+is "the process exited and the envelope is present", with NO interactive-log or
+TUI scraping. That makes background mode far simpler and more robust here than in
+a harness that tails an interactive CLI.
+
+State lives on disk (keyed by workspace), so status/result/cancel keep working
+across MCP server restarts. There is no daemon: reaping (deadline-kill of
+overrunning jobs, TTL cleanup, count cap) happens lazily on each lifecycle call,
+and ``--max-budget-usd`` still hard-bounds spend even for a job nobody polls.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import signal
+import subprocess
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+from uuid import uuid4
+
+from cc_plugin_codex.normalize import apply_cost_usage, normalize_envelope
+from cc_plugin_codex.schemas import ContextSummary, Meta
+
+STATE_ENV = "CC_PLUGIN_CODEX_STATE_DIR"
+TTL_ENV = "CC_PLUGIN_CODEX_JOB_TTL"
+MAX_SECONDS_ENV = "CC_PLUGIN_CODEX_JOB_MAX_SECONDS"
+MAX_COUNT_ENV = "CC_PLUGIN_CODEX_JOB_MAX_COUNT"
+
+DEFAULT_TTL = 86_400          # delete terminal job records after 24h
+DEFAULT_MAX_SECONDS = 1_800   # wall-clock cap; a poll past this reaps the job
+DEFAULT_MAX_COUNT = 50        # retained jobs per workspace; evict oldest terminal
+
+_TERMINAL = {"done", "failed", "cancelled", "timeout", "expired"}
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, ""))
+    except (TypeError, ValueError):
+        return default
+
+
+def max_seconds() -> int:
+    return _int_env(MAX_SECONDS_ENV, DEFAULT_MAX_SECONDS)
+
+
+def _state_root() -> Path:
+    root = os.environ.get(STATE_ENV)
+    if root:
+        return Path(root)
+    return Path(os.path.expanduser("~")) / ".cache" / "cc-plugin-codex" / "jobs"
+
+
+def _ws_dir(cwd: str) -> Path:
+    canonical = os.path.realpath(cwd)
+    digest = hashlib.sha256(canonical.encode()).hexdigest()[:12]
+    base = os.path.basename(canonical.rstrip("/")) or "workspace"
+    safe = "".join(c if (c.isalnum() or c in "._-") else "-" for c in base)[:40] or "ws"
+    return _state_root() / f"{safe}-{digest}"
+
+
+def _job_dir(cwd: str, job_id: str) -> Path:
+    return _ws_dir(cwd) / job_id
+
+
+def _pid_alive(pid: Optional[int]) -> bool:
+    if not pid:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _is_running(pid: Optional[int]) -> bool:
+    """Whether the job process is still running.
+
+    The job is launched detached but is still our child until it exits, so we
+    must reap it with waitpid — otherwise it lingers as a zombie that kill(0)
+    reports as 'alive' forever. waitpid(WNOHANG) returns (pid, _) once it exits
+    (reaping it), (0, 0) while it runs, and raises ChildProcessError if it is not
+    our child (e.g. after a server restart), where we fall back to a kill(0)
+    liveness probe."""
+    if not pid:
+        return False
+    try:
+        reaped, _ = os.waitpid(pid, os.WNOHANG)
+        if reaped == pid:
+            return False
+        if reaped == 0:
+            return True
+    except ChildProcessError:
+        pass  # not our child — use the liveness probe below
+    except OSError:
+        return False
+    return _pid_alive(pid)
+
+
+def _kill_pid_tree(pid: Optional[int]) -> None:
+    """Kill the detached job's process group (it is its own session leader), then
+    reap it if it was our child so it does not linger as a zombie."""
+    if not pid:
+        return
+    try:
+        if hasattr(os, "killpg"):
+            os.killpg(os.getpgid(pid), signal.SIGKILL)
+        else:  # pragma: no cover - non-POSIX fallback
+            os.kill(pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+    try:
+        os.waitpid(pid, 0)
+    except (ChildProcessError, OSError):
+        pass
+
+
+def _read_meta(jd: Path) -> Optional[dict]:
+    try:
+        return json.loads((jd / "meta.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _write_meta(jd: Path, meta: dict) -> None:
+    (jd / "meta.json").write_text(json.dumps(meta))
+
+
+def _read_envelope(jd: Path) -> Optional[dict]:
+    """Parse the claude JSON envelope from result.json, or None if absent/partial."""
+    try:
+        text = (jd / "result.json").read_text()
+    except OSError:
+        return None
+    text = text.strip()
+    if not text:
+        return None
+    try:
+        env = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return env if isinstance(env, dict) else None
+
+
+@dataclass
+class JobConfig:
+    kind: str
+    config_mode: str
+    access: str
+    scope: Optional[str]
+    base: Optional[str]
+    detail: str
+    timeout_seconds: int
+    workspace_source: Optional[str]
+    context_summary: Optional[ContextSummary]
+
+
+def start_job(cmd: list[str], cwd: str, cfg: JobConfig) -> tuple[str, str]:
+    """Spawn the claude command detached and persist its record.
+
+    Returns (job_id, started_at_iso)."""
+    job_id = uuid4().hex
+    jd = _job_dir(cwd, job_id)
+    jd.mkdir(parents=True, exist_ok=True)
+    # Best-effort: results contain the diff; keep the workspace tree user-only.
+    try:
+        os.chmod(_ws_dir(cwd), 0o700)
+    except OSError:
+        pass
+    started = time.time()
+    result_path = jd / "result.json"
+    stderr_path = jd / "stderr.log"
+    with open(result_path, "w") as rf, open(stderr_path, "w") as ef:
+        proc = subprocess.Popen(cmd, cwd=cwd, stdout=rf, stderr=ef, text=True,
+                                start_new_session=True)
+    summary = cfg.context_summary.model_dump() if cfg.context_summary else None
+    meta = {
+        "job_id": job_id, "kind": cfg.kind, "pid": proc.pid,
+        "started_epoch": started,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "deadline_epoch": started + max_seconds(),
+        "completed_epoch": None,
+        "terminal_status": None,   # set by cancel/deadline reap
+        "config": {
+            "config_mode": cfg.config_mode, "access": cfg.access,
+            "scope": cfg.scope, "base": cfg.base, "detail": cfg.detail,
+            "timeout_seconds": cfg.timeout_seconds,
+            "workspace_source": cfg.workspace_source, "cwd": cwd,
+        },
+        "context_summary": summary,
+    }
+    _write_meta(jd, meta)
+    _enforce_count_cap(cwd)
+    return job_id, meta["started_at"]
+
+
+def _status_of(jd: Path, meta: dict) -> str:
+    """Compute the live status, killing + marking jobs that overran their deadline."""
+    terminal = meta.get("terminal_status")
+    if terminal:
+        return terminal
+    if _is_running(meta.get("pid")):
+        if time.time() > meta.get("deadline_epoch", float("inf")):
+            _kill_pid_tree(meta.get("pid"))
+            meta["terminal_status"] = "timeout"
+            meta["completed_epoch"] = time.time()
+            _write_meta(jd, meta)
+            return "timeout"
+        return "running"
+    # Process gone: done if it left a parseable envelope, else it crashed.
+    if meta.get("completed_epoch") is None:
+        meta["completed_epoch"] = time.time()
+        _write_meta(jd, meta)
+    return "done" if _read_envelope(jd) is not None else "failed"
+
+
+def _elapsed_ms(meta: dict) -> int:
+    end = meta.get("completed_epoch") or time.time()
+    return max(0, int((end - meta.get("started_epoch", end)) * 1000))
+
+
+def _reap_workspace(cwd: str) -> None:
+    """Lazy maintenance: refresh statuses and delete expired terminal records."""
+    ws = _ws_dir(cwd)
+    if not ws.is_dir():
+        return
+    ttl = _int_env(TTL_ENV, DEFAULT_TTL)
+    now = time.time()
+    for jd in ws.iterdir():
+        if not jd.is_dir():
+            continue
+        meta = _read_meta(jd)
+        if meta is None:
+            continue
+        status = _status_of(jd, meta)
+        if status in _TERMINAL:
+            end = meta.get("completed_epoch") or meta.get("started_epoch") or now
+            if now - end > ttl:
+                _rmtree(jd)
+
+
+def _enforce_count_cap(cwd: str) -> None:
+    ws = _ws_dir(cwd)
+    cap = _int_env(MAX_COUNT_ENV, DEFAULT_MAX_COUNT)
+    dirs = [d for d in ws.iterdir() if d.is_dir()] if ws.is_dir() else []
+    if len(dirs) <= cap:
+        return
+    # Evict oldest terminal jobs first; never kill a still-running one to fit.
+    scored = []
+    for jd in dirs:
+        meta = _read_meta(jd) or {}
+        status = _status_of(jd, meta)
+        scored.append((status in _TERMINAL, meta.get("started_epoch", 0.0), jd))
+    scored.sort(key=lambda t: (not t[0], t[1]))  # terminal first, then oldest
+    for is_terminal, _epoch, jd in scored[: max(0, len(dirs) - cap)]:
+        if is_terminal:
+            _rmtree(jd)
+
+
+def _rmtree(jd: Path) -> None:
+    try:
+        for child in jd.iterdir():
+            child.unlink(missing_ok=True)
+        jd.rmdir()
+    except OSError:
+        pass
+
+
+def _build_meta(meta: dict, status: str) -> Meta:
+    c = meta.get("config", {})
+    return Meta(
+        cwd=c.get("cwd", ""),
+        workspace_source=c.get("workspace_source"),
+        config_mode=c.get("config_mode", "inherit"),
+        access=c.get("access", "toolless"),
+        scope=c.get("scope"), base=c.get("base"),
+        timeout_seconds=c.get("timeout_seconds", max_seconds()),
+        elapsed_ms=_elapsed_ms(meta),
+        job_id=meta.get("job_id"),
+    )
+
+
+def status(cwd: str, job_id: str) -> Optional[dict]:
+    """Return a JobStatus dict, or None if the job does not exist."""
+    _reap_workspace(cwd)
+    jd = _job_dir(cwd, job_id)
+    meta = _read_meta(jd)
+    if meta is None:
+        return None
+    state = _status_of(jd, meta)
+    cost = None
+    if state == "done":
+        env = _read_envelope(jd) or {}
+        c = env.get("total_cost_usd")
+        cost = float(c) if isinstance(c, (int, float)) else None
+    detail = None
+    if state == "failed":
+        detail = _stderr_tail(jd)
+    return {
+        "ok": True, "job_id": job_id, "kind": meta.get("kind", ""),
+        "status": state, "started_at": meta.get("started_at", ""),
+        "elapsed_ms": _elapsed_ms(meta),
+        "deadline_seconds": max_seconds(),
+        "result_available": state == "done",
+        "cost_usd": cost, "detail": detail,
+    }
+
+
+def _stderr_tail(jd: Path, limit: int = 200) -> Optional[str]:
+    try:
+        text = (jd / "stderr.log").read_text().strip()
+    except OSError:
+        return None
+    return text[-limit:] or None
+
+
+def result(cwd: str, job_id: str, consume: bool = False):
+    """Return (payload, found). payload is the normalized SuccessResult|ErrorResult
+    dict; found is False when no such job exists."""
+    _reap_workspace(cwd)
+    jd = _job_dir(cwd, job_id)
+    meta = _read_meta(jd)
+    if meta is None:
+        return None, False
+    state = _status_of(jd, meta)
+    if state == "done":
+        env_text = (jd / "result.json").read_text()
+        summary = meta.get("context_summary")
+        ctx_summary = ContextSummary(**summary) if summary else None
+        payload = normalize_envelope(
+            meta.get("kind", "claude_review_changes"), env_text,
+            _build_meta(meta, state), detail=meta.get("config", {}).get("detail", "summary"),
+            context_summary=ctx_summary,
+        )
+        if consume:
+            _rmtree(jd)
+        return payload, True
+    # Non-done states map to an error envelope so the contract stays ok-discriminated.
+    payload = _job_error(meta, state, jd)
+    return payload, True
+
+
+_STATE_TO_ERROR = {
+    "running": ("job_running", "The job is still running.",
+                "Poll claude_job_status; call claude_job_result once status=done."),
+    "cancelled": ("job_cancelled", "The job was cancelled.",
+                  "Start a new job; a cancelled run cannot be resumed."),
+    "timeout": ("job_timeout", "The job exceeded its wall-clock deadline and was stopped.",
+                "Narrow the scope or raise CC_PLUGIN_CODEX_JOB_MAX_SECONDS, then start a new job."),
+    "expired": ("job_failed", "The job record expired and was cleaned up.",
+                "Start a new job."),
+}
+
+
+def _job_error(meta: dict, state: str, jd: Path) -> dict:
+    from cc_plugin_codex.schemas import ErrorInfo, ErrorResult
+    if state == "failed":
+        code, message, repair = (
+            "job_failed",
+            f"The job failed without producing a result. {_stderr_tail(jd) or ''}".strip(),
+            "Run claude_status to check the CLI is installed and authenticated, then retry.",
+        )
+        retryable = True
+    else:
+        code, message, repair = _STATE_TO_ERROR.get(
+            state, ("job_failed", "The job did not complete.", "Start a new job."))
+        retryable = state == "running"
+    bmeta = _build_meta(meta, state)
+    # Surface any spend the (possibly partial) envelope recorded.
+    env = _read_envelope(jd)
+    if env:
+        apply_cost_usage(bmeta, env)
+    return ErrorResult(
+        error=ErrorInfo(code=code, message=message, repair=repair, retryable=retryable),
+        meta=bmeta,
+    ).model_dump(mode="json", exclude_none=True)
+
+
+def cancel(cwd: str, job_id: str) -> Optional[dict]:
+    """Kill a running job and mark it cancelled. Returns a JobStatus dict or None."""
+    _reap_workspace(cwd)
+    jd = _job_dir(cwd, job_id)
+    meta = _read_meta(jd)
+    if meta is None:
+        return None
+    state = _status_of(jd, meta)
+    if state not in _TERMINAL:
+        _kill_pid_tree(meta.get("pid"))
+        meta["terminal_status"] = "cancelled"
+        meta["completed_epoch"] = time.time()
+        _write_meta(jd, meta)
+    return status(cwd, job_id)

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/schemas.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/schemas.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 # Bump this whenever the agent-visible surface changes: tool names, input or
 # output schemas, the ErrorCode set, the config_mode/access/scope/detail value
 # sets, or the capability guarantees in CAPABILITY_SUMMARY. Clients cache by it.
-FINGERPRINT = "cc-plugin-codex/0.1/schema-5"
+FINGERPRINT = "cc-plugin-codex/0.1/schema-6"
 
 Severity = Literal["critical", "high", "medium", "low", "nit"]
 Verdict = Literal["pass", "concerns", "fail", "unknown"]
@@ -20,6 +20,8 @@ Access = Literal["toolless", "readonly"]
 Scope = Literal["working_tree", "staged", "branch"]
 Detail = Literal["summary", "full"]
 Effort = Literal["low", "medium", "high", "xhigh", "max"]
+# Lifecycle states for a background job. Terminal: done|failed|cancelled|timeout|expired.
+JobState = Literal["running", "done", "failed", "cancelled", "timeout", "expired"]
 
 ErrorCode = Literal[
     "claude_not_found", "claude_auth_required", "api_key_required",
@@ -27,6 +29,8 @@ ErrorCode = Literal[
     "invalid_workspace_root",
     "context_too_large", "timeout", "budget_exceeded", "claude_permission_error",
     "nonzero_exit", "invalid_json", "internal_error",
+    # Background-job lifecycle errors (claude_job_result for a non-done job):
+    "job_not_found", "job_running", "job_cancelled", "job_timeout", "job_failed",
 ]
 
 
@@ -80,6 +84,7 @@ class Meta(BaseModel):
     permission_denials: Optional[list] = None
     cost_usd: Optional[float] = None
     usage: Optional[Usage] = None
+    job_id: Optional[str] = None   # set on background-job results; None for sync calls
     request_id: str = Field(default_factory=lambda: uuid4().hex)
     fingerprint: str = FINGERPRINT
 
@@ -161,6 +166,35 @@ class CapabilitiesResult(BaseModel):
     prerequisites: list[str]
 
 
+class JobStarted(BaseModel):
+    """Returned by the *_async tools: a handle to poll, not a result."""
+    model_config = ConfigDict(extra="forbid")
+    ok: Literal[True] = True
+    job_id: str
+    kind: str                  # the tool the job runs, e.g. claude_review_changes
+    status: JobState = "running"
+    started_at: str            # ISO-8601 UTC
+    deadline_seconds: int      # wall-clock cap after which a poll reaps the job
+    meta: Meta
+    fingerprint: str = FINGERPRINT
+
+
+class JobStatus(BaseModel):
+    """Returned by claude_job_status: lifecycle state without the full result."""
+    model_config = ConfigDict(extra="forbid")
+    ok: Literal[True] = True
+    job_id: str
+    kind: str
+    status: JobState
+    started_at: str
+    elapsed_ms: int
+    deadline_seconds: int
+    result_available: bool = False   # true once status == done
+    cost_usd: Optional[float] = None  # populated for terminal jobs that spent
+    detail: Optional[str] = None      # short human hint (e.g. failure reason)
+    fingerprint: str = FINGERPRINT
+
+
 def _object_union_schema(adapter: TypeAdapter) -> dict:
     """Wrap a model union's anyOf in a top-level object schema.
 
@@ -185,3 +219,7 @@ def _object_union_schema(adapter: TypeAdapter) -> dict:
 RESULT_SCHEMA = _object_union_schema(TypeAdapter(SuccessResult | ErrorResult))
 STATUS_SCHEMA = StatusResult.model_json_schema()
 CAPABILITIES_SCHEMA = CapabilitiesResult.model_json_schema()
+# A failed *_async launch (e.g. context_too_large) returns the error envelope, so
+# the start tools advertise the JobStarted|ErrorResult union.
+JOB_STARTED_SCHEMA = _object_union_schema(TypeAdapter(JobStarted | ErrorResult))
+JOB_STATUS_SCHEMA = _object_union_schema(TypeAdapter(JobStatus | ErrorResult))

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/schemas.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/schemas.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 # Bump this whenever the agent-visible surface changes: tool names, input or
 # output schemas, the ErrorCode set, the config_mode/access/scope/detail value
 # sets, or the capability guarantees in CAPABILITY_SUMMARY. Clients cache by it.
-FINGERPRINT = "cc-plugin-codex/0.1/schema-4"
+FINGERPRINT = "cc-plugin-codex/0.1/schema-5"
 
 Severity = Literal["critical", "high", "medium", "low", "nit"]
 Verdict = Literal["pass", "concerns", "fail", "unknown"]
@@ -19,6 +19,7 @@ ConfigMode = Literal["inherit", "scoped", "bare"]
 Access = Literal["toolless", "readonly"]
 Scope = Literal["working_tree", "staged", "branch"]
 Detail = Literal["summary", "full"]
+Effort = Literal["low", "medium", "high", "xhigh", "max"]
 
 ErrorCode = Literal[
     "claude_not_found", "claude_auth_required", "api_key_required",
@@ -120,6 +121,7 @@ class ResolvedDefaults(BaseModel):
     config_mode: ConfigMode
     access: Access
     model: Optional[str] = None
+    effort: Effort
     max_budget_usd: float
     timeout_seconds: int
     budget_bounds: list[float]   # [min, max] clamp range for max_budget_usd
@@ -131,6 +133,11 @@ class StatusResult(BaseModel):
     ok: Literal[True] = True
     claude_found: bool
     claude_version: Optional[str] = None
+    # Readiness probes (all free — no paid Claude call):
+    claude_authenticated: Optional[bool] = None   # None = could not determine
+    auth_detail: Optional[str] = None
+    version_supported: Optional[bool] = None       # matches the supported CLI major
+    ready: bool = False        # found AND a supported version AND authenticated
     config_modes_available: dict
     resolved_defaults: ResolvedDefaults
     caveat: str

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/schemas.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/schemas.py
@@ -20,8 +20,9 @@ Access = Literal["toolless", "readonly"]
 Scope = Literal["working_tree", "staged", "branch"]
 Detail = Literal["summary", "full"]
 Effort = Literal["low", "medium", "high", "xhigh", "max"]
-# Lifecycle states for a background job. Terminal: done|failed|cancelled|timeout|expired.
-JobState = Literal["running", "done", "failed", "cancelled", "timeout", "expired"]
+# Lifecycle states for a background job. Terminal: done|failed|cancelled|timeout.
+# (TTL-expired records are deleted and reported as job_not_found, not a state.)
+JobState = Literal["running", "done", "failed", "cancelled", "timeout"]
 
 ErrorCode = Literal[
     "claude_not_found", "claude_auth_required", "api_key_required",

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
@@ -489,7 +489,10 @@ async def claude_review_changes_async(
                       effort=effort)
     if err:
         return _result(err)
-    meta = _meta(cwd, r.config_mode, r.access, r.timeout, 0, None, scope, base,
+    # A background job is bounded by its wall-clock deadline, not the synchronous
+    # timeout_seconds; report that everywhere so meta stays consistent with the job.
+    job_timeout = jobs.max_seconds()
+    meta = _meta(cwd, r.config_mode, r.access, job_timeout, 0, None, scope, base,
                  workspace_source=ws_source)
     try:
         ctx_data = await anyio.to_thread.run_sync(
@@ -505,7 +508,7 @@ async def claude_review_changes_async(
         return _result(_err("internal_error", f"git failed: {e}",
                        "Ensure cwd is a git repo and base ref exists.", meta))
     if ctx_data.truncated:
-        meta = _meta(cwd, r.config_mode, r.access, r.timeout, 0, None, scope, base,
+        meta = _meta(cwd, r.config_mode, r.access, job_timeout, 0, None, scope, base,
                      truncated=True, hint=ctx_data.truncation_hint, workspace_source=ws_source)
         return _result(_err("context_too_large", "The diff is too large to review safely.",
                        ctx_data.truncation_hint or "Narrow the scope.", meta))
@@ -520,8 +523,8 @@ async def claude_review_changes_async(
         lambda: jobs.start_job(cmd, cwd, cfg))
     started = JobStarted(
         job_id=job_id, kind="claude_review_changes", started_at=started_at,
-        deadline_seconds=jobs.max_seconds(),
-        meta=_meta(cwd, r.config_mode, r.access, r.timeout, 0, None, scope, base,
+        deadline_seconds=job_timeout,
+        meta=_meta(cwd, r.config_mode, r.access, job_timeout, 0, None, scope, base,
                    workspace_source=ws_source),
     )
     return _result(started.model_dump(mode="json", exclude_none=True))
@@ -538,10 +541,10 @@ async def claude_job_status(
     """Report a background job's lifecycle state (free; no Claude call).
 
     Returns {ok, job_id, status, elapsed_ms, result_available, cost_usd?} where
-    status is running|done|failed|cancelled|timeout|expired. Call
-    claude_job_result once result_available is true. A running job past its
-    deadline is stopped and reported as timeout here. Returns job_not_found if the
-    id is unknown (or its record expired).
+    status is running|done|failed|cancelled|timeout. Call claude_job_result once
+    result_available is true. A running job past its deadline is stopped and
+    reported as timeout here. Returns job_not_found if the id is unknown (or its
+    record was cleaned up after the TTL).
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
@@ -15,10 +15,13 @@ from fastmcp import Context, FastMCP
 from fastmcp.tools.tool import ToolResult
 from pydantic import Field
 
-from cc_plugin_codex.claude import build_command, classify_failure, run_claude_async
+from cc_plugin_codex.claude import (
+    auth_status, build_command, classify_failure, run_claude_async,
+)
 from cc_plugin_codex.config import (
     MAX_BUDGET_USD, MAX_TIMEOUT_SECONDS, MIN_BUDGET_USD, MIN_TIMEOUT_SECONDS,
-    bare_available, clamp_budget, clamp_timeout, defaults,
+    VALID_EFFORTS, bare_available, clamp_budget, clamp_timeout, defaults,
+    sanitize_effort, version_supported,
 )
 from cc_plugin_codex.context import (
     InvalidBaseError, InvalidScopeError, gather_context,
@@ -26,7 +29,7 @@ from cc_plugin_codex.context import (
 from cc_plugin_codex.normalize import apply_cost_usage, build_prompt, normalize_envelope
 from cc_plugin_codex.schemas import (
     CAPABILITIES_SCHEMA, FINGERPRINT, RESULT_SCHEMA, STATUS_SCHEMA,
-    Access, CapabilitiesResult, ConfigMode, Detail,
+    Access, CapabilitiesResult, ConfigMode, Detail, Effort,
     ErrorInfo, ErrorResult, Meta, ResolvedDefaults, Scope, StatusResult,
 )
 
@@ -51,7 +54,7 @@ CAPABILITY_SUMMARY = (
     "cannot be resumed; narrow the scope or lower timeout_seconds to bound a call. "
     "Prerequisite: the `claude` CLI installed and authenticated; config_mode=bare "
     "additionally requires ANTHROPIC_API_KEY. "
-    "Note: in claude 2.1.161 there is no OAuth-preserving way to fully strip "
+    "Note: in claude 2.1.x there is no OAuth-preserving way to fully strip "
     "CLAUDE.md/memory — full config independence (config_mode=bare) requires an API key. "
     "Invalid enum-typed arguments are rejected as schema validation errors before "
     "a tool runs (not via the ok:false envelope). "
@@ -150,10 +153,11 @@ class Resolved:
     budget: float
     timeout: int
     detail: str
+    effort: str
 
 
 def _resolve(config_mode, access, model, max_budget_usd, timeout_seconds, detail,
-             cwd, scope=None, base=None, workspace_source=None):
+             cwd, scope=None, base=None, workspace_source=None, effort=None):
     """Resolve env defaults + clamps and validate. Returns (Resolved, None) or (None, error_dict)."""
     d = defaults()
     cm = config_mode or d.config_mode
@@ -162,6 +166,7 @@ def _resolve(config_mode, access, model, max_budget_usd, timeout_seconds, detail
     budget = clamp_budget(max_budget_usd if max_budget_usd is not None else d.max_budget_usd)
     timeout = clamp_timeout(timeout_seconds if timeout_seconds is not None else d.timeout_seconds)
     det = detail if detail in ("summary", "full") else "summary"
+    eff = effort if effort in VALID_EFFORTS else d.effort
 
     # Validate before building Meta (Meta uses Literal types — invalid values
     # would raise Pydantic errors before we can return a structured response).
@@ -184,14 +189,14 @@ def _resolve(config_mode, access, model, max_budget_usd, timeout_seconds, detail
                           "config_mode=bare requires ANTHROPIC_API_KEY, which is unset.",
                           "Set ANTHROPIC_API_KEY, or use config_mode inherit/scoped.",
                           meta, offending="config_mode")
-    return Resolved(cm, ac, mdl, budget, timeout, det), None
+    return Resolved(cm, ac, mdl, budget, timeout, det, eff), None
 
 
 async def _execute(tool, payload, r: Resolved, cwd,
                    scope=None, base=None, context_text="", context_summary=None,
                    workspace_source=None) -> dict:
     prompt = build_prompt(tool, payload, context_text)
-    cmd = build_command(prompt, r.config_mode, r.access, r.model, r.budget)
+    cmd = build_command(prompt, r.config_mode, r.access, r.model, r.budget, r.effort)
     run = await run_claude_async(cmd, cwd=cwd, timeout_seconds=r.timeout)
     meta = _meta(cwd, r.config_mode, r.access, r.timeout, run.elapsed_ms, run.exit_code,
                  scope, base, workspace_source=workspace_source)
@@ -221,6 +226,9 @@ async def claude_ask(
     config_mode: Annotated[Optional[ConfigMode], Field(description="inherit|scoped|bare")] = None,
     access: Annotated[Optional[Access], Field(description="toolless|readonly")] = None,
     model: Optional[str] = None,
+    effort: Annotated[Optional[Effort], Field(
+        description="Reasoning effort: low|medium|high|xhigh|max. "
+        "Raise for high-stakes reviews; omit to use the server default.")] = None,
     max_budget_usd: Optional[float] = None,
     timeout_seconds: Optional[int] = None,
     detail: Annotated[Detail, Field(description="summary|full")] = "summary",
@@ -254,7 +262,7 @@ async def claude_ask(
                        "Pass workspace_root as an absolute path to an existing directory, or "
                        "configure an MCP root.", meta, offending="workspace_root"))
     r, err = _resolve(config_mode, access, model, max_budget_usd, timeout_seconds,
-                      detail, cwd, workspace_source=ws_source)
+                      detail, cwd, workspace_source=ws_source, effort=effort)
     if err:
         return _result(err)
     payload = {"prompt": prompt, "context": context}
@@ -274,6 +282,9 @@ async def claude_review_changes(
     config_mode: Annotated[Optional[ConfigMode], Field(description="inherit|scoped|bare")] = None,
     access: Annotated[Optional[Access], Field(description="toolless|readonly")] = None,
     model: Optional[str] = None,
+    effort: Annotated[Optional[Effort], Field(
+        description="Reasoning effort: low|medium|high|xhigh|max. "
+        "Raise for high-stakes reviews; omit to use the server default.")] = None,
     max_budget_usd: Optional[float] = None,
     timeout_seconds: Optional[int] = None,
     detail: Annotated[Detail, Field(description="summary|full")] = "summary",
@@ -308,7 +319,8 @@ async def claude_review_changes(
                        "configure an MCP root.", meta, offending="workspace_root"))
     # Validate options BEFORE touching git, so bad config isn't masked by git errors.
     r, err = _resolve(config_mode, access, model, max_budget_usd, timeout_seconds,
-                      detail, cwd, scope=scope, base=base, workspace_source=ws_source)
+                      detail, cwd, scope=scope, base=base, workspace_source=ws_source,
+                      effort=effort)
     if err:
         return _result(err)
     meta = _meta(cwd, r.config_mode, r.access, r.timeout, 0, None, scope, base,
@@ -351,6 +363,9 @@ async def claude_adversarial_review(
     config_mode: Annotated[Optional[ConfigMode], Field(description="inherit|scoped|bare")] = None,
     access: Annotated[Optional[Access], Field(description="toolless|readonly")] = None,
     model: Optional[str] = None,
+    effort: Annotated[Optional[Effort], Field(
+        description="Reasoning effort: low|medium|high|xhigh|max. "
+        "Raise for high-stakes reviews; omit to use the server default.")] = None,
     max_budget_usd: Optional[float] = None,
     timeout_seconds: Optional[int] = None,
     detail: Annotated[Detail, Field(description="summary|full")] = "summary",
@@ -380,7 +395,8 @@ async def claude_adversarial_review(
                        "Pass workspace_root as an absolute path to an existing directory, or "
                        "configure an MCP root.", meta, offending="workspace_root"))
     r, err = _resolve(config_mode, access, model, max_budget_usd, timeout_seconds,
-                      detail, cwd, scope=scope, base=base, workspace_source=ws_source)
+                      detail, cwd, scope=scope, base=base, workspace_source=ws_source,
+                      effort=effort)
     if err:
         return _result(err)
     context_text = ""
@@ -430,17 +446,25 @@ def claude_status() -> ToolResult:
     """
     found = shutil.which("claude") is not None
     version = None
+    authenticated: bool | None = None
+    auth_detail: str | None = None
+    supported: bool | None = None
     if found:
         try:
             version = subprocess.run(["claude", "--version"], capture_output=True,
                                      text=True, timeout=10).stdout.strip()
         except Exception:
             version = None
+        supported = version_supported(version)
+        # Free auth probe: lets an agent discover a logged-out CLI before
+        # spending money on a paid call that would only then fail auth.
+        authenticated, auth_detail = auth_status()
     d = defaults()
     resolved = ResolvedDefaults(
         config_mode=d.config_mode if d.config_mode in ("inherit", "scoped", "bare") else "inherit",
         access=d.access if d.access in ("toolless", "readonly") else "toolless",
         model=d.model,
+        effort=sanitize_effort(d.effort),
         max_budget_usd=clamp_budget(d.max_budget_usd),
         timeout_seconds=clamp_timeout(d.timeout_seconds),
         budget_bounds=[MIN_BUDGET_USD, MAX_BUDGET_USD],
@@ -449,11 +473,15 @@ def claude_status() -> ToolResult:
     status = StatusResult(
         claude_found=found,
         claude_version=version,
+        claude_authenticated=authenticated,
+        auth_detail=auth_detail,
+        version_supported=supported,
+        ready=bool(found and supported and authenticated),
         config_modes_available={
             "inherit": True, "scoped": True, "bare": bare_available(),
         },
         resolved_defaults=resolved,
-        caveat=("OAuth-preserving + CLAUDE.md-free is impossible in claude 2.1.161; "
+        caveat=("OAuth-preserving + CLAUDE.md-free is impossible in claude 2.1.x; "
                 "config_mode=bare needs ANTHROPIC_API_KEY."),
     )
     return _result(status.model_dump(mode="json", exclude_none=True))

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
@@ -26,11 +26,14 @@ from cc_plugin_codex.config import (
 from cc_plugin_codex.context import (
     InvalidBaseError, InvalidScopeError, gather_context,
 )
+from cc_plugin_codex import jobs
+from cc_plugin_codex.jobs import JobConfig
 from cc_plugin_codex.normalize import apply_cost_usage, build_prompt, normalize_envelope
 from cc_plugin_codex.schemas import (
-    CAPABILITIES_SCHEMA, FINGERPRINT, RESULT_SCHEMA, STATUS_SCHEMA,
+    CAPABILITIES_SCHEMA, FINGERPRINT, JOB_STARTED_SCHEMA, JOB_STATUS_SCHEMA,
+    RESULT_SCHEMA, STATUS_SCHEMA,
     Access, CapabilitiesResult, ConfigMode, Detail, Effort,
-    ErrorInfo, ErrorResult, Meta, ResolvedDefaults, Scope, StatusResult,
+    ErrorInfo, ErrorResult, JobStarted, Meta, ResolvedDefaults, Scope, StatusResult,
 )
 
 CAPABILITY_SUMMARY = (
@@ -433,6 +436,192 @@ async def claude_adversarial_review(
     return _result(out)
 
 
+# Starting a background job commits to spend (the job runs to completion or its
+# budget cap even if never polled), but returns immediately without blocking.
+_ASYNC_START_ANNOTATIONS = {
+    "readOnlyHint": True, "openWorldHint": True,
+    "destructiveHint": False, "idempotentHint": False,
+}
+
+
+@mcp.tool(annotations=_ASYNC_START_ANNOTATIONS, title="Review changes with Claude (background)",
+          output_schema=JOB_STARTED_SCHEMA)
+async def claude_review_changes_async(
+    scope: Annotated[Scope, Field(description="working_tree|staged|branch")],
+    base: Annotated[str, Field(description="Base ref for scope=branch.")] = "main",
+    focus: Annotated[Optional[str], Field(description="e.g. 'security', 'tests'.")] = None,
+    workspace_root: Annotated[Optional[str], Field(
+        description="Absolute path to the repo/workspace to operate in. If omitted, "
+        "the server uses the client's first MCP root, else its own cwd.")] = None,
+    config_mode: Annotated[Optional[ConfigMode], Field(description="inherit|scoped|bare")] = None,
+    access: Annotated[Optional[Access], Field(description="toolless|readonly")] = None,
+    model: Optional[str] = None,
+    effort: Annotated[Optional[Effort], Field(
+        description="Reasoning effort: low|medium|high|xhigh|max.")] = None,
+    max_budget_usd: Optional[float] = None,
+    detail: Annotated[Detail, Field(description="summary|full")] = "summary",
+    ctx: Context = None,
+) -> ToolResult:
+    """Launch a Claude diff review as a BACKGROUND job and return immediately.
+
+    Unlike claude_review_changes (which blocks), this returns a job handle
+    {ok, job_id, status:"running", ...} right away; the review keeps running
+    detached. Poll claude_job_status(job_id), then claude_job_result(job_id) once
+    status=done. Use this for large diffs or when you want to keep working while
+    Claude reviews. Paid (commits to spend) + read-only. The diff is gathered now,
+    with the same secret redaction and budget cap as the synchronous tool.
+
+    The job is bounded by max_budget_usd and a wall-clock deadline
+    (CC_PLUGIN_CODEX_JOB_MAX_SECONDS, default 1800s) enforced on the next status
+    poll. timeout_seconds does not apply (there is no blocking call to time out).
+    Error codes mirror claude_review_changes for the launch phase (e.g.
+    invalid_scope, invalid_base, context_too_large, unsupported_config_mode).
+    """
+    cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
+    if ws_err:
+        meta = _meta("", "inherit", "toolless", 0, 0, None)
+        return _result(_err(ws_err,
+                       f"workspace_root '{workspace_root}' is not an existing absolute directory.",
+                       "Pass workspace_root as an absolute path to an existing directory, or "
+                       "configure an MCP root.", meta, offending="workspace_root"))
+    r, err = _resolve(config_mode, access, model, max_budget_usd, None,
+                      detail, cwd, scope=scope, base=base, workspace_source=ws_source,
+                      effort=effort)
+    if err:
+        return _result(err)
+    meta = _meta(cwd, r.config_mode, r.access, r.timeout, 0, None, scope, base,
+                 workspace_source=ws_source)
+    try:
+        ctx_data = await anyio.to_thread.run_sync(
+            lambda: gather_context(cwd, scope=scope, base=base))
+    except InvalidBaseError:
+        return _result(_err("invalid_base", f"Invalid base ref '{base}'.",
+                       "Use an existing git ref matching [A-Za-z0-9._/-]+ that does "
+                       "not start with '-'.", meta, offending="base"))
+    except InvalidScopeError:
+        return _result(_err("invalid_scope", f"Invalid scope '{scope}'.",
+                       "Use working_tree, staged, or branch.", meta, offending="scope"))
+    except RuntimeError as e:
+        return _result(_err("internal_error", f"git failed: {e}",
+                       "Ensure cwd is a git repo and base ref exists.", meta))
+    if ctx_data.truncated:
+        meta = _meta(cwd, r.config_mode, r.access, r.timeout, 0, None, scope, base,
+                     truncated=True, hint=ctx_data.truncation_hint, workspace_source=ws_source)
+        return _result(_err("context_too_large", "The diff is too large to review safely.",
+                       ctx_data.truncation_hint or "Narrow the scope.", meta))
+    prompt = build_prompt("claude_review_changes",
+                          {"scope": scope, "base": base, "focus": focus}, ctx_data.text)
+    cmd = build_command(prompt, r.config_mode, r.access, r.model, r.budget, r.effort)
+    cfg = JobConfig(kind="claude_review_changes", config_mode=r.config_mode,
+                    access=r.access, scope=scope, base=base, detail=r.detail,
+                    timeout_seconds=jobs.max_seconds(), workspace_source=ws_source,
+                    context_summary=ctx_data.summary)
+    job_id, started_at = await anyio.to_thread.run_sync(
+        lambda: jobs.start_job(cmd, cwd, cfg))
+    started = JobStarted(
+        job_id=job_id, kind="claude_review_changes", started_at=started_at,
+        deadline_seconds=jobs.max_seconds(),
+        meta=_meta(cwd, r.config_mode, r.access, r.timeout, 0, None, scope, base,
+                   workspace_source=ws_source),
+    )
+    return _result(started.model_dump(mode="json", exclude_none=True))
+
+
+@mcp.tool(annotations=_STATUS_ANNOTATIONS, title="Background job status",
+          output_schema=JOB_STATUS_SCHEMA)
+async def claude_job_status(
+    job_id: Annotated[str, Field(description="A job_id from an *_async tool.")],
+    workspace_root: Annotated[Optional[str], Field(
+        description="Workspace the job belongs to (defaults like the async tools).")] = None,
+    ctx: Context = None,
+) -> ToolResult:
+    """Report a background job's lifecycle state (free; no Claude call).
+
+    Returns {ok, job_id, status, elapsed_ms, result_available, cost_usd?} where
+    status is running|done|failed|cancelled|timeout|expired. Call
+    claude_job_result once result_available is true. A running job past its
+    deadline is stopped and reported as timeout here. Returns job_not_found if the
+    id is unknown (or its record expired).
+    """
+    cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
+    if ws_err:
+        meta = _meta("", "inherit", "toolless", 0, 0, None)
+        return _result(_err(ws_err, "workspace_root is not an existing absolute directory.",
+                       "Pass an absolute path or configure an MCP root.", meta,
+                       offending="workspace_root"))
+    data = await anyio.to_thread.run_sync(lambda: jobs.status(cwd, job_id))
+    if data is None:
+        meta = _meta(cwd, "inherit", "toolless", 0, 0, None, workspace_source=ws_source)
+        return _result(_err("job_not_found", f"No job '{job_id}' in this workspace.",
+                       "Check the job_id, or start a new job; records expire after the TTL.",
+                       meta, offending="job_id"))
+    return _result(data)
+
+
+@mcp.tool(annotations=_STATUS_ANNOTATIONS, title="Background job result",
+          output_schema=RESULT_SCHEMA)
+async def claude_job_result(
+    job_id: Annotated[str, Field(description="A job_id from an *_async tool.")],
+    consume: Annotated[bool, Field(
+        description="Delete the job record after returning the result.")] = False,
+    workspace_root: Annotated[Optional[str], Field(
+        description="Workspace the job belongs to (defaults like the async tools).")] = None,
+    ctx: Context = None,
+) -> ToolResult:
+    """Fetch a finished background job's review (free; no new Claude call).
+
+    On success returns the SAME envelope as the synchronous tools (ok, verdict,
+    confidence, findings, meta.cost_usd, ...), with meta.job_id set — reuse your
+    existing result parser. If the job is not yet done it returns an ok:false
+    error: job_running (poll and retry), job_cancelled, job_timeout, or job_failed;
+    job_not_found if the id is unknown. Pass consume=true to delete the record once
+    you have the result.
+    """
+    cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
+    if ws_err:
+        meta = _meta("", "inherit", "toolless", 0, 0, None)
+        return _result(_err(ws_err, "workspace_root is not an existing absolute directory.",
+                       "Pass an absolute path or configure an MCP root.", meta,
+                       offending="workspace_root"))
+    payload, found = await anyio.to_thread.run_sync(
+        lambda: jobs.result(cwd, job_id, consume))
+    if not found:
+        meta = _meta(cwd, "inherit", "toolless", 0, 0, None, workspace_source=ws_source)
+        return _result(_err("job_not_found", f"No job '{job_id}' in this workspace.",
+                       "Check the job_id, or start a new job; records expire after the TTL.",
+                       meta, offending="job_id"))
+    return _result(payload)
+
+
+@mcp.tool(annotations=_STATUS_ANNOTATIONS, title="Cancel background job",
+          output_schema=JOB_STATUS_SCHEMA)
+async def claude_job_cancel(
+    job_id: Annotated[str, Field(description="A job_id from an *_async tool.")],
+    workspace_root: Annotated[Optional[str], Field(
+        description="Workspace the job belongs to (defaults like the async tools).")] = None,
+    ctx: Context = None,
+) -> ToolResult:
+    """Stop a running background job (free; terminates the Claude process).
+
+    Kills the detached Claude process and marks the job cancelled; a cancelled job
+    cannot be resumed. Returns the resulting JobStatus, or job_not_found. Already
+    terminal jobs are returned unchanged.
+    """
+    cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
+    if ws_err:
+        meta = _meta("", "inherit", "toolless", 0, 0, None)
+        return _result(_err(ws_err, "workspace_root is not an existing absolute directory.",
+                       "Pass an absolute path or configure an MCP root.", meta,
+                       offending="workspace_root"))
+    data = await anyio.to_thread.run_sync(lambda: jobs.cancel(cwd, job_id))
+    if data is None:
+        meta = _meta(cwd, "inherit", "toolless", 0, 0, None, workspace_source=ws_source)
+        return _result(_err("job_not_found", f"No job '{job_id}' in this workspace.",
+                       "Check the job_id, or start a new job; records expire after the TTL.",
+                       meta, offending="job_id"))
+    return _result(data)
+
+
 @mcp.tool(annotations=_STATUS_ANNOTATIONS, title="Claude CLI status & defaults",
           output_schema=STATUS_SCHEMA)
 def claude_status() -> ToolResult:
@@ -502,14 +691,17 @@ def cc_codex_capabilities() -> ToolResult:
         version="0.1.0",
         transport="stdio",
         stability="experimental",
-        paid_tools=["claude_ask", "claude_review_changes", "claude_adversarial_review"],
-        free_tools=["claude_status", "cc_codex_capabilities"],
+        paid_tools=["claude_ask", "claude_review_changes", "claude_adversarial_review",
+                    "claude_review_changes_async"],
+        free_tools=["claude_status", "cc_codex_capabilities", "claude_job_status",
+                    "claude_job_result", "claude_job_cancel"],
         config_modes=["inherit", "scoped", "bare"],
         access_modes=["toolless", "readonly"],
         scope=[
             "independent code review of a git diff",
             "adversarial review of a plan/claim",
             "a free-form independent second opinion",
+            "background diff review with poll/result/cancel for long runs",
         ],
         negative_scope=[
             "does NOT edit code or run shell",

--- a/plugins/cc-plugin-codex/tests/test_claude.py
+++ b/plugins/cc-plugin-codex/tests/test_claude.py
@@ -40,11 +40,25 @@ def test_build_command_toolless_inherit():
                         model=None, max_budget_usd=1.0)
     assert cmd[0] == "claude"
     assert "-p" in cmd and "--output-format" in cmd and "json" in cmd
+    assert "--no-chrome" in cmd  # avoid an interactive Chrome picker hanging the call
     assert "--no-session-persistence" in cmd
     assert "--tools" in cmd
     assert "--append-system-prompt" in cmd
     assert cmd[-2] == "--"
     assert cmd[-1] == "hi"  # prompt is the final positional arg
+
+
+def test_build_command_effort_flag():
+    cmd = build_command(prompt="hi", config_mode="inherit", access="toolless",
+                        model=None, max_budget_usd=1.0, effort="xhigh")
+    assert "--effort" in cmd
+    assert cmd[cmd.index("--effort") + 1] == "xhigh"
+
+
+def test_build_command_omits_effort_when_none():
+    cmd = build_command(prompt="hi", config_mode="inherit", access="toolless",
+                        model=None, max_budget_usd=1.0)
+    assert "--effort" not in cmd
 
 
 def test_build_command_model():

--- a/plugins/cc-plugin-codex/tests/test_config.py
+++ b/plugins/cc-plugin-codex/tests/test_config.py
@@ -69,3 +69,27 @@ def test_readonly_allowlist_has_no_write_tools():
     assert ro[1] == "Read,Grep,Glob"  # allowlist contains only read tools
     for bad in ("Edit", "Write", "NotebookEdit", "Bash"):
         assert bad not in ro[1]
+
+
+def test_default_effort(monkeypatch):
+    monkeypatch.delenv("CC_PLUGIN_CODEX_EFFORT", raising=False)
+    assert cfg.defaults().effort == cfg.DEFAULT_EFFORT
+
+
+def test_effort_from_env(monkeypatch):
+    monkeypatch.setenv("CC_PLUGIN_CODEX_EFFORT", "xhigh")
+    assert cfg.defaults().effort == "xhigh"
+
+
+def test_sanitize_effort_falls_back_on_invalid():
+    assert cfg.sanitize_effort("bogus") == cfg.DEFAULT_EFFORT
+    assert cfg.sanitize_effort(None) == cfg.DEFAULT_EFFORT
+    for level in cfg.VALID_EFFORTS:
+        assert cfg.sanitize_effort(level) == level
+
+
+def test_version_supported():
+    assert cfg.version_supported("2.1.162 (Claude Code)") is True
+    assert cfg.version_supported("3.0.0") is False
+    assert cfg.version_supported("garbage") is None
+    assert cfg.version_supported(None) is None

--- a/plugins/cc-plugin-codex/tests/test_jobs.py
+++ b/plugins/cc-plugin-codex/tests/test_jobs.py
@@ -1,0 +1,139 @@
+"""Background-job lifecycle tests.
+
+These drive jobs.start_job with a fake command (not the real `claude`) that writes
+a known JSON envelope, so the full start -> status -> result/cancel/timeout flow is
+exercised deterministically and for free.
+"""
+
+import json
+import time
+
+import pytest
+
+from cc_plugin_codex import jobs
+from cc_plugin_codex.jobs import JobConfig
+
+_INNER = {
+    "summary": "off-by-one bug", "verdict": "concerns", "confidence": "high",
+    "findings": [{"severity": "high", "title": "subtraction", "file": "app.py",
+                  "line": 2, "evidence": "a - b", "risk": "wrong", "recommendation": "use +"}],
+    "questions": [], "assumptions": [],
+}
+_ENVELOPE = json.dumps({
+    "type": "result", "subtype": "success", "is_error": False,
+    "result": json.dumps(_INNER), "session_id": "sess-1",
+    "total_cost_usd": 0.0123, "usage": {"input_tokens": 100, "output_tokens": 50},
+})
+
+
+def _cfg(**over):
+    base = dict(kind="claude_review_changes", config_mode="inherit", access="toolless",
+                scope="working_tree", base="main", detail="summary",
+                timeout_seconds=1800, workspace_source="cwd", context_summary=None)
+    base.update(over)
+    return JobConfig(**base)
+
+
+def _emit_cmd(envelope=_ENVELOPE):
+    # `printf %s "$0"` writes the envelope (passed as $0) to stdout -> result.json.
+    return ["sh", "-c", "printf '%s' \"$0\"", envelope]
+
+
+def _sleep_cmd(seconds=30):
+    return ["sh", "-c", f"sleep {seconds}"]
+
+
+@pytest.fixture(autouse=True)
+def _state_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("CC_PLUGIN_CODEX_STATE_DIR", str(tmp_path / "state"))
+
+
+def _await_done(cwd, job_id, timeout=5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        st = jobs.status(cwd, job_id)
+        if st and st["status"] != "running":
+            return st
+        time.sleep(0.05)
+    raise AssertionError("job did not leave running state in time")
+
+
+def test_job_done_returns_normalized_result(tmp_path):
+    cwd = str(tmp_path)
+    job_id, started_at = jobs.start_job(_emit_cmd(), cwd, _cfg())
+    assert started_at
+    st = _await_done(cwd, job_id)
+    assert st["status"] == "done"
+    assert st["result_available"] is True
+    assert st["cost_usd"] == 0.0123
+
+    payload, found = jobs.result(cwd, job_id)
+    assert found is True
+    assert payload["ok"] is True
+    assert payload["verdict"] == "concerns"
+    assert payload["meta"]["job_id"] == job_id
+    assert payload["meta"]["cost_usd"] == 0.0123
+
+
+def test_job_running_then_result_says_job_running(tmp_path):
+    cwd = str(tmp_path)
+    job_id, _ = jobs.start_job(_sleep_cmd(), cwd, _cfg())
+    st = jobs.status(cwd, job_id)
+    assert st["status"] == "running"
+    assert st["result_available"] is False
+
+    payload, found = jobs.result(cwd, job_id)
+    assert found is True
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "job_running"
+    assert payload["error"]["retryable"] is True
+    jobs.cancel(cwd, job_id)  # clean up the sleeper
+
+
+def test_job_cancel(tmp_path):
+    cwd = str(tmp_path)
+    job_id, _ = jobs.start_job(_sleep_cmd(), cwd, _cfg())
+    assert jobs.status(cwd, job_id)["status"] == "running"
+    st = jobs.cancel(cwd, job_id)
+    assert st["status"] == "cancelled"
+
+    payload, found = jobs.result(cwd, job_id)
+    assert found is True
+    assert payload["error"]["code"] == "job_cancelled"
+
+
+def test_job_timeout_on_deadline(tmp_path, monkeypatch):
+    monkeypatch.setenv("CC_PLUGIN_CODEX_JOB_MAX_SECONDS", "0")  # deadline = start time
+    cwd = str(tmp_path)
+    job_id, _ = jobs.start_job(_sleep_cmd(), cwd, _cfg())
+    st = jobs.status(cwd, job_id)  # first poll past deadline reaps it
+    assert st["status"] == "timeout"
+    payload, _ = jobs.result(cwd, job_id)
+    assert payload["error"]["code"] == "job_timeout"
+
+
+def test_job_not_found(tmp_path):
+    cwd = str(tmp_path)
+    assert jobs.status(cwd, "nope") is None
+    assert jobs.cancel(cwd, "nope") is None
+    payload, found = jobs.result(cwd, "nope")
+    assert found is False
+
+
+def test_terminal_job_reaped_after_ttl(tmp_path, monkeypatch):
+    cwd = str(tmp_path)
+    job_id, _ = jobs.start_job(_emit_cmd(), cwd, _cfg())
+    _await_done(cwd, job_id)
+    # TTL of 0 means a terminal record is eligible for cleanup on the next call.
+    monkeypatch.setenv("CC_PLUGIN_CODEX_JOB_TTL", "0")
+    time.sleep(0.02)
+    assert jobs.status(cwd, job_id) is None  # reaped
+
+
+def test_consume_deletes_record(tmp_path):
+    cwd = str(tmp_path)
+    job_id, _ = jobs.start_job(_emit_cmd(), cwd, _cfg())
+    _await_done(cwd, job_id)
+    payload, found = jobs.result(cwd, job_id, consume=True)
+    assert found is True and payload["ok"] is True
+    assert jobs.status(cwd, job_id) is None  # gone after consume

--- a/plugins/cc-plugin-codex/tests/test_jobs.py
+++ b/plugins/cc-plugin-codex/tests/test_jobs.py
@@ -66,6 +66,10 @@ def test_job_done_returns_normalized_result(tmp_path):
     assert st["status"] == "done"
     assert st["result_available"] is True
     assert st["cost_usd"] == 0.0123
+    # Status output conforms to the published contract: carries the fingerprint and
+    # reports the deadline window the job started with (1800s), not a live env read.
+    assert st["fingerprint"]
+    assert st["deadline_seconds"] == 1800
 
     payload, found = jobs.result(cwd, job_id)
     assert found is True

--- a/plugins/cc-plugin-codex/tests/test_schemas.py
+++ b/plugins/cc-plugin-codex/tests/test_schemas.py
@@ -38,7 +38,7 @@ def test_success_result_has_next_steps():
 
 
 def test_fingerprint_value():
-    assert FINGERPRINT == "cc-plugin-codex/0.1/schema-4"
+    assert FINGERPRINT == "cc-plugin-codex/0.1/schema-5"
 
 
 def test_success_result_dump_omits_none():

--- a/plugins/cc-plugin-codex/tests/test_schemas.py
+++ b/plugins/cc-plugin-codex/tests/test_schemas.py
@@ -38,7 +38,7 @@ def test_success_result_has_next_steps():
 
 
 def test_fingerprint_value():
-    assert FINGERPRINT == "cc-plugin-codex/0.1/schema-5"
+    assert FINGERPRINT == "cc-plugin-codex/0.1/schema-6"
 
 
 def test_success_result_dump_omits_none():

--- a/plugins/cc-plugin-codex/tests/test_server.py
+++ b/plugins/cc-plugin-codex/tests/test_server.py
@@ -158,7 +158,7 @@ async def test_claude_ask_returns_normalized(fake_claude):
     data = structured(result)
     assert data["ok"] is True
     assert data["verdict"] == "concerns"
-    assert data["meta"]["fingerprint"] == "cc-plugin-codex/0.1/schema-4"
+    assert data["meta"]["fingerprint"] == "cc-plugin-codex/0.1/schema-5"
 
 
 async def test_invalid_enum_param_rejected_by_schema(fake_claude):
@@ -218,10 +218,48 @@ async def test_status_reports_resolved_defaults(monkeypatch):
     rd = structured(result)["resolved_defaults"]
     assert rd["config_mode"] == "scoped"
     assert rd["access"] == "toolless"
+    assert rd["effort"] == "xhigh"              # depth-first default effort
     assert rd["max_budget_usd"] == 5.0          # clamped to MAX_BUDGET_USD
     assert rd["timeout_seconds"] == 180
     assert rd["budget_bounds"] == [0.01, 5.0]
     assert rd["timeout_bounds"] == [10, 600]
+
+
+async def test_status_reports_readiness(monkeypatch):
+    # claude_status must surface auth + version-compatibility for FREE, so an
+    # agent can detect a logged-out or incompatible CLI before any paid call.
+    import cc_plugin_codex.server as srv
+
+    monkeypatch.setattr(srv.shutil, "which", lambda _: "/usr/bin/claude")
+
+    class _Ver:
+        stdout = "2.1.162 (Claude Code)"
+
+    monkeypatch.setattr(srv.subprocess, "run", lambda *a, **k: _Ver())
+    monkeypatch.setattr(srv, "auth_status", lambda *a, **k: (True, "Logged in"))
+    async with Client(mcp) as client:
+        result = await client.call_tool("claude_status", {})
+    data = structured(result)
+    assert data["claude_authenticated"] is True
+    assert data["version_supported"] is True
+    assert data["ready"] is True
+
+
+async def test_status_not_ready_when_logged_out(monkeypatch):
+    import cc_plugin_codex.server as srv
+
+    monkeypatch.setattr(srv.shutil, "which", lambda _: "/usr/bin/claude")
+
+    class _Ver:
+        stdout = "2.1.162 (Claude Code)"
+
+    monkeypatch.setattr(srv.subprocess, "run", lambda *a, **k: _Ver())
+    monkeypatch.setattr(srv, "auth_status", lambda *a, **k: (False, "Not logged in"))
+    async with Client(mcp) as client:
+        result = await client.call_tool("claude_status", {})
+    data = structured(result)
+    assert data["claude_authenticated"] is False
+    assert data["ready"] is False
 
 
 async def test_env_default_config_mode_used(fake_claude, monkeypatch):
@@ -334,7 +372,7 @@ async def test_capabilities_tool_returns_structured_contract():
     async with Client(mcp) as client:
         result = await client.call_tool("cc_codex_capabilities", {})
     data = structured(result)
-    assert data["fingerprint"] == "cc-plugin-codex/0.1/schema-4"
+    assert data["fingerprint"] == "cc-plugin-codex/0.1/schema-5"
     assert data["transport"] == "stdio"
     assert set(data["paid_tools"]) == {
         "claude_ask", "claude_review_changes", "claude_adversarial_review"}

--- a/plugins/cc-plugin-codex/tests/test_server.py
+++ b/plugins/cc-plugin-codex/tests/test_server.py
@@ -1,5 +1,6 @@
 import json
 
+import anyio
 import pytest
 from fastmcp import Client
 
@@ -158,7 +159,7 @@ async def test_claude_ask_returns_normalized(fake_claude):
     data = structured(result)
     assert data["ok"] is True
     assert data["verdict"] == "concerns"
-    assert data["meta"]["fingerprint"] == "cc-plugin-codex/0.1/schema-5"
+    assert data["meta"]["fingerprint"] == "cc-plugin-codex/0.1/schema-6"
 
 
 async def test_invalid_enum_param_rejected_by_schema(fake_claude):
@@ -366,17 +367,76 @@ async def test_review_invalid_workspace_root_is_structured_error(fake_claude):
     assert data["error"]["offending_param"] == "workspace_root"
 
 
+async def test_review_changes_async_lifecycle(monkeypatch, git_repo, tmp_path):
+    # End-to-end through the MCP surface: launch async -> poll status -> get the
+    # same envelope as the sync tool. build_command is replaced with a fake that
+    # writes a known claude envelope, so no real CLI runs.
+    import json as _json
+
+    import cc_plugin_codex.server as srv
+
+    monkeypatch.setenv("CC_PLUGIN_CODEX_STATE_DIR", str(tmp_path / "state"))
+    inner = {"summary": "off-by-one", "verdict": "concerns", "confidence": "high",
+             "findings": [], "questions": [], "assumptions": []}
+    envelope = _json.dumps({"type": "result", "subtype": "success", "is_error": False,
+                            "result": _json.dumps(inner), "total_cost_usd": 0.02,
+                            "usage": {"input_tokens": 5, "output_tokens": 1}})
+    monkeypatch.setattr(srv, "build_command",
+                        lambda *a, **k: ["sh", "-c", "printf '%s' \"$0\"", envelope])
+
+    async with Client(mcp) as client:
+        started = structured(await client.call_tool(
+            "claude_review_changes_async",
+            {"scope": "working_tree", "workspace_root": str(git_repo)}))
+        assert started["ok"] is True
+        assert started["status"] == "running"
+        job_id = started["job_id"]
+
+        import time as _time
+        deadline = _time.time() + 5
+        status = "running"
+        while _time.time() < deadline:
+            st = structured(await client.call_tool(
+                "claude_job_status",
+                {"job_id": job_id, "workspace_root": str(git_repo)}))
+            status = st["status"]
+            if status != "running":
+                break
+            await anyio.sleep(0.05)
+        assert status == "done"
+
+        res = structured(await client.call_tool(
+            "claude_job_result", {"job_id": job_id, "workspace_root": str(git_repo)}))
+    assert res["ok"] is True
+    assert res["verdict"] == "concerns"
+    assert res["meta"]["job_id"] == job_id
+
+
+async def test_job_result_not_found_is_structured_error(tmp_path, monkeypatch, git_repo):
+    monkeypatch.setenv("CC_PLUGIN_CODEX_STATE_DIR", str(tmp_path / "state"))
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "claude_job_result", {"job_id": "deadbeef", "workspace_root": str(git_repo)},
+            raise_on_error=False)
+    data = structured(result)
+    assert data["ok"] is False
+    assert data["error"]["code"] == "job_not_found"
+
+
 async def test_capabilities_tool_returns_structured_contract():
     # F7: the capability/version contract is available as structured data, not
     # only as a prose resource.
     async with Client(mcp) as client:
         result = await client.call_tool("cc_codex_capabilities", {})
     data = structured(result)
-    assert data["fingerprint"] == "cc-plugin-codex/0.1/schema-5"
+    assert data["fingerprint"] == "cc-plugin-codex/0.1/schema-6"
     assert data["transport"] == "stdio"
     assert set(data["paid_tools"]) == {
-        "claude_ask", "claude_review_changes", "claude_adversarial_review"}
+        "claude_ask", "claude_review_changes", "claude_adversarial_review",
+        "claude_review_changes_async"}
     assert "claude_status" in data["free_tools"]
+    for lifecycle in ("claude_job_status", "claude_job_result", "claude_job_cancel"):
+        assert lifecycle in data["free_tools"]
     assert data["negative_scope"]            # non-empty list of what it won't do
     assert data["prerequisites"]
 


### PR DESCRIPTION
Improvements to `cc-plugin-codex` informed by a comparison with [`yanchuk/claude-plugin-codex`](https://github.com/yanchuk/claude-plugin-codex), reviewed with Codex.

## Quick wins (`64b744c`)

- **`claude_status` readiness probes** (all free, no paid call): `claude_authenticated` (via `claude auth status`), `version_supported` (against the supported CLI major), and a combined `ready` flag — so an agent can detect a logged-out or incompatible CLI before spending on a paid call that would only then fail.
- **`effort` control**: new `low|medium|high|xhigh|max` param on the paid tools plus `CC_PLUGIN_CODEX_EFFORT`, defaulting to `xhigh` (review depth is the whole point of this server). Passed through to `claude --effort`; invalid values degrade to the default rather than failing the call.
- **`--no-chrome`** in `build_command` to stop an interactive Chrome picker from hanging an unattended run until the timeout.

## Background review jobs — Phase 1 (`e88b539`)

A detached background path so long reviews no longer block the Codex turn, as an **explicit lifecycle** rather than hidden state:

- `claude_review_changes_async` launches the review detached and returns a typed `JobStarted` handle immediately. The diff is gathered at launch with the same secret redaction and `--max-budget-usd` cap as the sync tool.
- `claude_job_status` / `claude_job_result` / `claude_job_cancel` manage the job (free). `claude_job_result` returns the **same** `SuccessResult|ErrorResult` envelope as the sync tools, with `meta.job_id` set, so clients reuse their existing parser.

Because the server drives one-shot `claude -p --output-format json`, completion is "process exited + JSON envelope present" — no interactive-log scraping. State is persisted on disk keyed by workspace, so the lifecycle survives an MCP server restart. Jobs are reaped lazily on each poll (deadline-kill via `CC_PLUGIN_CODEX_JOB_MAX_SECONDS`, TTL cleanup, count cap); the budget cap bounds spend even for an unpolled job. Detached children are reaped with `waitpid` so they don't linger as zombies that look "running".

Fingerprint bumped to `schema-6` (new tools, `Meta.job_id`, `job_*` error codes).

## Tests

- **115 passing**, `ruff check` clean.
- New: 8 background-job lifecycle tests + an async end-to-end test through the MCP surface, all driven by fake commands (no paid `claude` calls).

## Follow-ups (not in this PR)

- Phase 2: extend async to `claude_ask`/`claude_adversarial_review`, add `claude_jobs_list`.
- Widen `SUPPORTED_MAJOR` when Claude Code moves to 3.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)