### PR TITLE
Tighten cc-plugin-codex agent contract

### DIFF
--- a/plugins/cc-plugin-codex/.codex-plugin/plugin.json
+++ b/plugins/cc-plugin-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-plugin-codex",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Call Claude Code from Codex for bounded, independent code review and second opinions",
   "author": { "name": "Brian Connelly", "url": "https://github.com/briandconnelly" },
   "repository": "https://github.com/briandconnelly/cc-plugin-codex",

--- a/plugins/cc-plugin-codex/README.md
+++ b/plugins/cc-plugin-codex/README.md
@@ -11,7 +11,8 @@ tasks. Reviews can run synchronously or as background jobs, but Claude only ever
 An MCP server wraps the `claude` CLI and exposes read-only tools to Codex:
 `claude_ask`, `claude_review_changes`, `claude_adversarial_review`, and `claude_status`,
 plus `claude_review_changes_async` with `claude_job_status`/`claude_job_result`/
-`claude_job_cancel` for background reviews. Claude reviews; it never edits your code.
+`claude_job_consume_result`/`claude_job_cancel` for background reviews. Claude reviews;
+it never edits your code.
 
 Each tool publishes an output schema describing the `ok`-discriminated result
 (`{"ok": true, ...}` on success, `{"ok": false, "error": {code, message, repair}, ...}`
@@ -21,6 +22,9 @@ on failure). Failures also set the MCP `isError` flag, so branch on either `ok` 
 Invalid values for enum-typed parameters (`config_mode`, `access`, `scope`, `detail`)
 are rejected by the MCP framework as a schema validation error before the tool runs,
 rather than via the `ok:false` envelope; every other failure uses the envelope.
+The capability fingerprint changes whenever the agent-visible contract changes.
+Deprecated tools remain discoverable during their compatibility window, with their
+replacement named in the tool description and capability summary.
 
 The paid tools (`claude_ask`, `claude_review_changes`, `claude_adversarial_review`)
 **block synchronously** for up to `timeout_seconds` (default 180s, max 600s).
@@ -75,6 +79,9 @@ The diff-bearing tools operate on a workspace resolved in this order: an explici
 `workspace_root` argument, then the client's first MCP root, then the server's own
 working directory.
 `meta.workspace_source` reports which rule applied.
+When the client provides MCP roots, an explicit `workspace_root` must be contained
+inside one of those roots; otherwise the tool returns `workspace_outside_roots`.
+Clients that do not provide roots may still pass any existing absolute directory.
 Pass `workspace_root` explicitly when launching the server from a fixed directory (e.g. a
 plugin install) so reviews target your project rather than the plugin checkout.
 
@@ -97,17 +104,22 @@ plugin install) so reviews target your project rather than the plugin checkout.
 handle `{ok, job_id, status:"running", …}` immediately instead of blocking the Codex
 turn. Poll `claude_job_status(job_id)`, then call `claude_job_result(job_id)` once
 `result_available` is true — the result is the **same** `ok`/`verdict`/`findings`
-envelope the synchronous tool returns, with `meta.job_id` set. `claude_job_cancel`
-terminates a running job. The status/result/cancel tools are free.
+envelope the synchronous tool returns, with `meta.job_id` set. `claude_job_result`
+is read-only and leaves the stored record available until TTL cleanup. Use
+`claude_job_consume_result(job_id)` to fetch a finished result and delete the record.
+`claude_job_cancel` terminates a running job. The status/result/consume/cancel tools
+are free.
 
 The diff is gathered at launch (same secret redaction and `--max-budget-usd` cap as the
 sync path). Because the server drives one-shot `claude -p --output-format json`, a job's
 completion is simply "the process exited and wrote its JSON envelope" — no interactive
 log scraping. State lives on disk keyed by workspace, so status/result/cancel survive an
 MCP server restart. There is no daemon: overrunning jobs are stopped on the next status
-poll (deadline `CC_PLUGIN_CODEX_JOB_MAX_SECONDS`, default 1800s), records are cleaned up
-after `CC_PLUGIN_CODEX_JOB_TTL` (default 24h), and the budget cap bounds spend even for a
-job nobody polls. Job records (which contain the diff) are stored under
+poll (deadline `CC_PLUGIN_CODEX_JOB_MAX_SECONDS`, default 1800s). Job start/status
+responses include `poll_after_ms`, `ttl_seconds`, and `expires_at` where known.
+Records are cleaned up after `CC_PLUGIN_CODEX_JOB_TTL` (default 24h), and the budget
+cap bounds spend even for a job nobody polls. Job records (which contain the diff)
+are stored under
 `CC_PLUGIN_CODEX_STATE_DIR` (default `~/.cache/cc-plugin-codex/jobs`); anyone with access
 to that workspace's state directory can read or cancel its jobs.
 

--- a/plugins/cc-plugin-codex/prek.toml
+++ b/plugins/cc-plugin-codex/prek.toml
@@ -1,0 +1,31 @@
+# Configuration file for `prek`, a git hook framework written in Rust.
+#:schema https://www.schemastore.org/prek.json
+
+[[repos]]
+repo = "builtin"
+hooks = [
+  { id = "check-json", files = '^plugins/cc-plugin-codex/' },
+  { id = "end-of-file-fixer", files = '^plugins/cc-plugin-codex/' },
+  { id = "trailing-whitespace", files = '^plugins/cc-plugin-codex/' },
+]
+
+[[repos]]
+repo = "local"
+
+[[repos.hooks]]
+id = "ruff-check"
+name = "ruff check"
+entry = "uv"
+args = ["--directory", "plugins/cc-plugin-codex", "run", "ruff", "check", "."]
+language = "system"
+pass_filenames = false
+always_run = true
+
+[[repos.hooks]]
+id = "pytest"
+name = "pytest"
+entry = "uv"
+args = ["--directory", "plugins/cc-plugin-codex", "run", "pytest"]
+language = "system"
+pass_filenames = false
+always_run = true

--- a/plugins/cc-plugin-codex/pyproject.toml
+++ b/plugins/cc-plugin-codex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cc-plugin-codex"
-version = "0.1.0"
+version = "0.1.1"
 description = "Call Claude Code from Codex for bounded, independent code review and second opinions"
 requires-python = ">=3.10"
 dependencies = [

--- a/plugins/cc-plugin-codex/pyproject.toml
+++ b/plugins/cc-plugin-codex/pyproject.toml
@@ -21,6 +21,7 @@ packages = ["src/cc_plugin_codex"]
 
 [dependency-groups]
 dev = [
+    "prek>=0.4.4",
     "pytest>=8",
     "pytest-asyncio>=0.23",
     "ruff>=0.15.15",

--- a/plugins/cc-plugin-codex/skills/collaborating-with-claude/SKILL.md
+++ b/plugins/cc-plugin-codex/skills/collaborating-with-claude/SKILL.md
@@ -22,7 +22,7 @@ Do NOT call Claude in a loop, and never call Claude just because Claude suggeste
 
 - `claude_ask` — a free-form second opinion or recommendation.
 - `claude_review_changes` — Claude reviews your git diff (`scope` = working_tree | staged | branch).
-- `claude_review_changes_async` — same review as a background job for large diffs or when you want to keep working; returns a `job_id`. Poll `claude_job_status`, then `claude_job_result` (same envelope as the sync tool); `claude_job_cancel` to stop it.
+- `claude_review_changes_async` — same review as a background job for large diffs or when you want to keep working; returns a `job_id`. Poll `claude_job_status`, then `claude_job_result` (same envelope as the sync tool). Use `claude_job_consume_result` only when you want to fetch and delete the stored record; use `claude_job_cancel` to stop it.
 - `claude_adversarial_review` — Claude attacks a plan/claim and lists the strongest counterarguments.
 - `claude_status` — free readiness check: reports whether `claude` is installed, authenticated (`claude_authenticated`), version-compatible (`version_supported`), and overall `ready`, plus the resolved defaults a no-arg call would use. Run it first if a call fails, or to confirm readiness before spending.
 
@@ -38,5 +38,6 @@ Do NOT call Claude in a loop, and never call Claude just because Claude suggeste
 - Each call is PAID and sends your code/diff to Anthropic. Call deliberately.
 - The server never sends `.env`/secret files; redaction is filename-based, not content-scanning, so do not paste secrets into prompts and do not rely on it to catch secrets hardcoded inside ordinary source files.
 - Default access is `toolless` (Claude gets no tools) and `config_mode=inherit`; both access modes are read-only (Claude never gets write/Bash). Use `config_mode=bare` only when you want a fully independent reviewer and have `ANTHROPIC_API_KEY` set.
+- When client MCP roots are available, explicit `workspace_root` values must be inside one of those roots; omit `workspace_root` to use the first root.
 - Cap cost/time with `max_budget_usd` and `timeout_seconds` for large reviews.
 - Reviews run at `effort=xhigh` by default for depth. Lower `effort` to `high`/`medium` to save cost on routine changes; raise to `max` for the most subtle ones.

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/__init__.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/__init__.py
@@ -1,3 +1,5 @@
 """cc-plugin-codex: call Claude Code from Codex for bounded, read-only critique."""
 
-__version__ = "0.1.0"
+from importlib.metadata import version
+
+__version__ = version("cc-plugin-codex")

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/claude.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/claude.py
@@ -131,7 +131,7 @@ def classify_failure(run: ClaudeRun) -> ErrorInfo:
                          repair="Narrow the scope/focus or raise timeout_seconds.",
                          retryable=True)
     if "invalid api key" in blob:
-        return ErrorInfo(code="api_key_required",
+        return ErrorInfo(code="api_key_invalid",
                          message="ANTHROPIC_API_KEY is invalid.",
                          repair="Set a valid ANTHROPIC_API_KEY, or use config_mode "
                                 "inherit/scoped to use your existing login.")

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/context.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/context.py
@@ -108,7 +108,7 @@ def gather_context(cwd: str, scope: str, base: str) -> ContextResult:
     if len(encoded) > MAX_DIFF_BYTES:
         text = encoded[:MAX_DIFF_BYTES].decode("utf-8", "ignore")
         truncated = True
-        hint = (f"diff exceeded {MAX_DIFF_BYTES} bytes; narrow with a smaller "
-                f"scope or review specific files")
+        hint = (f"diff exceeded {MAX_DIFF_BYTES} bytes; use scope=staged, choose "
+                "a closer branch base, or call claude_ask with selected context")
     return ContextResult(text=text, summary=summary, truncated=truncated,
                          truncation_hint=hint, redacted_paths=redacted)

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/jobs.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/jobs.py
@@ -52,6 +52,14 @@ def max_seconds() -> int:
     return _int_env(MAX_SECONDS_ENV, DEFAULT_MAX_SECONDS)
 
 
+def ttl_seconds() -> int:
+    return _int_env(TTL_ENV, DEFAULT_TTL)
+
+
+def poll_after_ms() -> int:
+    return 1000
+
+
 def _state_root() -> Path:
     root = os.environ.get(STATE_ENV)
     if root:
@@ -239,12 +247,19 @@ def _deadline_seconds(meta: dict) -> int:
     return max_seconds()
 
 
+def _expires_at(meta: dict) -> Optional[str]:
+    completed = meta.get("completed_epoch")
+    if completed is None:
+        return None
+    return datetime.fromtimestamp(completed + ttl_seconds(), timezone.utc).isoformat()
+
+
 def _reap_workspace(cwd: str) -> None:
     """Lazy maintenance: refresh statuses and delete expired terminal records."""
     ws = _ws_dir(cwd)
     if not ws.is_dir():
         return
-    ttl = _int_env(TTL_ENV, DEFAULT_TTL)
+    ttl = ttl_seconds()
     now = time.time()
     for jd in ws.iterdir():
         if not jd.is_dir():
@@ -321,6 +336,9 @@ def status(cwd: str, job_id: str) -> Optional[dict]:
         "status": state, "started_at": meta.get("started_at", ""),
         "elapsed_ms": _elapsed_ms(meta),
         "deadline_seconds": _deadline_seconds(meta),
+        "poll_after_ms": poll_after_ms(),
+        "ttl_seconds": ttl_seconds(),
+        "expires_at": _expires_at(meta),
         "result_available": state == "done",
         "cost_usd": cost, "detail": detail,
         "fingerprint": FINGERPRINT,

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/schemas.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/schemas.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 # Bump this whenever the agent-visible surface changes: tool names, input or
 # output schemas, the ErrorCode set, the config_mode/access/scope/detail value
 # sets, or the capability guarantees in CAPABILITY_SUMMARY. Clients cache by it.
-FINGERPRINT = "cc-plugin-codex/0.1/schema-6"
+FINGERPRINT = "cc-plugin-codex/0.1/schema-7"
 
 Severity = Literal["critical", "high", "medium", "low", "nit"]
 Verdict = Literal["pass", "concerns", "fail", "unknown"]
@@ -25,9 +25,9 @@ Effort = Literal["low", "medium", "high", "xhigh", "max"]
 JobState = Literal["running", "done", "failed", "cancelled", "timeout"]
 
 ErrorCode = Literal[
-    "claude_not_found", "claude_auth_required", "api_key_required",
+    "claude_not_found", "claude_auth_required", "api_key_missing", "api_key_invalid",
     "unsupported_config_mode", "unsupported_access", "invalid_scope", "invalid_base",
-    "invalid_workspace_root",
+    "invalid_workspace_root", "workspace_outside_roots",
     "context_too_large", "timeout", "budget_exceeded", "claude_permission_error",
     "nonzero_exit", "invalid_json", "internal_error",
     # Background-job lifecycle errors (claude_job_result for a non-done job):
@@ -165,6 +165,7 @@ class CapabilitiesResult(BaseModel):
     scope: list[str]            # what this server is for
     negative_scope: list[str]   # what it deliberately does NOT do
     prerequisites: list[str]
+    deprecation_policy: str
 
 
 class JobStarted(BaseModel):
@@ -176,6 +177,9 @@ class JobStarted(BaseModel):
     status: JobState = "running"
     started_at: str            # ISO-8601 UTC
     deadline_seconds: int      # wall-clock cap after which a poll reaps the job
+    poll_after_ms: int = 1000
+    ttl_seconds: int
+    expires_at: Optional[str] = None
     meta: Meta
     fingerprint: str = FINGERPRINT
 
@@ -190,6 +194,9 @@ class JobStatus(BaseModel):
     started_at: str
     elapsed_ms: int
     deadline_seconds: int
+    poll_after_ms: int = 1000
+    ttl_seconds: int
+    expires_at: Optional[str] = None
     result_available: bool = False   # true once status == done
     cost_usd: Optional[float] = None  # populated for terminal jobs that spent
     detail: Optional[str] = None      # short human hint (e.g. failure reason)

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/schemas.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/schemas.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 # Bump this whenever the agent-visible surface changes: tool names, input or
 # output schemas, the ErrorCode set, the config_mode/access/scope/detail value
 # sets, or the capability guarantees in CAPABILITY_SUMMARY. Clients cache by it.
-FINGERPRINT = "cc-plugin-codex/0.1/schema-7"
+FINGERPRINT = "cc-plugin-codex/0.1/schema-8"
 
 Severity = Literal["critical", "high", "medium", "low", "nit"]
 Verdict = Literal["pass", "concerns", "fail", "unknown"]

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
@@ -131,6 +131,14 @@ def _workspace_error(code: str, workspace_root: str | None = None) -> dict:
             meta,
             offending="workspace_root",
         )
+    if workspace_root is None:
+        return _err(
+            code,
+            "The resolved workspace is not an existing absolute directory.",
+            "Pass workspace_root as an absolute path to an existing directory, "
+            "or configure an MCP root that points at an existing directory.",
+            meta,
+        )
     return _err(
         code,
         f"workspace_root '{workspace_root}' is not an existing absolute directory.",

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
@@ -520,7 +520,7 @@ async def claude_review_changes_async(
     return _result(started.model_dump(mode="json", exclude_none=True))
 
 
-@mcp.tool(annotations=_FREE_READ_ANNOTATIONS, title="Background job status",
+@mcp.tool(annotations=_LOCAL_MUTATION_ANNOTATIONS, title="Background job status",
           output_schema=JOB_STATUS_SCHEMA)
 async def claude_job_status(
     job_id: Annotated[str, Field(description="A job_id from an *_async tool.")],
@@ -546,7 +546,7 @@ async def claude_job_status(
     return _result(data)
 
 
-@mcp.tool(annotations=_FREE_READ_ANNOTATIONS, title="Background job result",
+@mcp.tool(annotations=_LOCAL_MUTATION_ANNOTATIONS, title="Background job result",
           output_schema=RESULT_SCHEMA)
 async def claude_job_result(
     job_id: Annotated[str, Field(description="A job_id from an *_async tool.")],

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
@@ -55,6 +55,13 @@ CAPABILITY_SUMMARY = (
     "synchronously for up to timeout_seconds (default 180s, max 600s), but CAN be "
     "cancelled by the client (which terminates the underlying Claude process) and "
     "cannot be resumed; narrow the scope or lower timeout_seconds to bound a call. "
+    "When client MCP roots are available, an explicit workspace_root must be inside "
+    "one of those roots; clients without roots may still pass an existing absolute path. "
+    "Background result fetch is read-only; use claude_job_consume_result to fetch and "
+    "delete a stored completed result. "
+    "Deprecated capabilities remain discoverable during their compatibility window "
+    "with replacement guidance, and every agent-visible contract change bumps the "
+    "fingerprint. "
     "Prerequisite: the `claude` CLI installed and authenticated; config_mode=bare "
     "additionally requires ANTHROPIC_API_KEY. "
     "Note: in claude 2.1.x there is no OAuth-preserving way to fully strip "
@@ -72,10 +79,15 @@ _PAID_ANNOTATIONS = {
     "readOnlyHint": True, "openWorldHint": True,
     "destructiveHint": False, "idempotentHint": False,
 }
-# claude_status is free, read-only, and safely repeatable.
-_STATUS_ANNOTATIONS = {
+# Free read-only tools are safely repeatable.
+_FREE_READ_ANNOTATIONS = {
     "readOnlyHint": True, "openWorldHint": False,
     "destructiveHint": False, "idempotentHint": True,
+}
+# Local job lifecycle mutations change only this server's job state.
+_LOCAL_MUTATION_ANNOTATIONS = {
+    "readOnlyHint": False, "openWorldHint": False,
+    "destructiveHint": False, "idempotentHint": False,
 }
 
 
@@ -108,22 +120,56 @@ def _err(code: str, message: str, repair: str, meta: Meta,
     ).model_dump(mode="json", exclude_none=True)
 
 
-async def _first_root(ctx) -> str | None:
-    """Return the filesystem path of the client's first file:// root, or None.
+def _workspace_error(code: str, workspace_root: str | None = None) -> dict:
+    meta = _meta("", "inherit", "toolless", 0, 0, None)
+    if code == "workspace_outside_roots":
+        return _err(
+            code,
+            f"workspace_root '{workspace_root}' is outside the client's MCP roots.",
+            "Pass a workspace_root contained by an MCP root, omit workspace_root to "
+            "use the first root, or configure the intended directory as a root.",
+            meta,
+            offending="workspace_root",
+        )
+    return _err(
+        code,
+        f"workspace_root '{workspace_root}' is not an existing absolute directory.",
+        "Pass workspace_root as an absolute path to an existing directory, or "
+        "configure an MCP root.",
+        meta,
+        offending="workspace_root",
+    )
 
-    Returns None if the client provides no roots or does not support the roots
+
+async def _file_roots(ctx) -> list[str]:
+    """Return filesystem paths from the client's file:// roots.
+
+    Returns [] if the client provides no roots or does not support the roots
     capability (list_roots raises)."""
     if ctx is None:
-        return None
+        return []
     try:
         roots = await ctx.list_roots()
     except Exception:
-        return None
+        return []
+    paths = []
     for root in roots or []:
         uri = str(getattr(root, "uri", ""))
         if uri.startswith("file://"):
-            return unquote(urlparse(uri).path)
-    return None
+            paths.append(unquote(urlparse(uri).path))
+    return paths
+
+
+async def _first_root(ctx) -> str | None:
+    roots = await _file_roots(ctx)
+    return roots[0] if roots else None
+
+
+def _contained_by(path: str, root: str) -> bool:
+    try:
+        return os.path.commonpath([os.path.realpath(path), os.path.realpath(root)]) == os.path.realpath(root)
+    except ValueError:
+        return False
 
 
 async def _resolve_workspace(workspace_root, ctx):
@@ -132,10 +178,11 @@ async def _resolve_workspace(workspace_root, ctx):
     Order: explicit workspace_root arg -> first file:// MCP root -> os.getcwd().
     Returns (path, error_code, source). error_code is None on success; on failure
     path is None and source is None."""
+    roots = await _file_roots(ctx)
     if workspace_root:
         path, source = workspace_root, "param"
     else:
-        root = await _first_root(ctx)
+        root = roots[0] if roots else None
         if root:
             path, source = root, "roots"
         else:
@@ -145,6 +192,8 @@ async def _resolve_workspace(workspace_root, ctx):
     # and os.getcwd() are always absolute already.
     if not os.path.isabs(path) or not os.path.isdir(path):
         return None, "invalid_workspace_root", None
+    if workspace_root and roots and not any(_contained_by(path, root) for root in roots):
+        return None, "workspace_outside_roots", None
     return path, None, source
 
 
@@ -188,7 +237,7 @@ def _resolve(config_mode, access, model, max_budget_usd, timeout_seconds, detail
     meta = _meta(cwd, cm, ac, timeout, 0, None, scope, base,
                  workspace_source=workspace_source)
     if cm == "bare" and not bare_available():
-        return None, _err("api_key_required",
+        return None, _err("api_key_missing",
                           "config_mode=bare requires ANTHROPIC_API_KEY, which is unset.",
                           "Set ANTHROPIC_API_KEY, or use config_mode inherit/scoped.",
                           meta, offending="config_mode")
@@ -249,21 +298,19 @@ async def claude_ask(
     other failures return ok:false. Errors come back as
     {"ok": false, "error": {code, message, repair}} with is_error set — branch on
     `ok`. Possible error codes: unsupported_config_mode, unsupported_access,
-    api_key_required, invalid_workspace_root, claude_not_found, claude_auth_required,
+    api_key_missing, api_key_invalid, invalid_workspace_root, workspace_outside_roots,
+    claude_not_found, claude_auth_required,
     claude_permission_error, timeout, budget_exceeded, nonzero_exit, invalid_json,
     internal_error.
 
     workspace_root: absolute path to the repo to operate in; if omitted, the
     server uses the client's first MCP root, else its own cwd (see meta.workspace_source).
-    Adds error code: invalid_workspace_root (path missing or not absolute).
+    Adds error codes: invalid_workspace_root (path missing or not absolute),
+    workspace_outside_roots (explicit path outside negotiated roots).
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
-        meta = _meta("", "inherit", "toolless", 0, 0, None)
-        return _result(_err(ws_err,
-                       f"workspace_root '{workspace_root}' is not an existing absolute directory.",
-                       "Pass workspace_root as an absolute path to an existing directory, or "
-                       "configure an MCP root.", meta, offending="workspace_root"))
+        return _result(_workspace_error(ws_err, workspace_root))
     r, err = _resolve(config_mode, access, model, max_budget_usd, timeout_seconds,
                       detail, cwd, workspace_source=ws_source, effort=effort)
     if err:
@@ -304,22 +351,20 @@ async def claude_review_changes(
     framework as a schema validation error BEFORE the tool runs and do NOT use the
     ok:false envelope; all other failures return ok:false. Branch on `ok` (is_error
     is set on failure); error codes: unsupported_config_mode, unsupported_access,
-    api_key_required, invalid_workspace_root, invalid_scope, invalid_base,
+    api_key_missing, api_key_invalid, invalid_workspace_root, workspace_outside_roots,
+    invalid_scope, invalid_base,
     context_too_large, claude_not_found, claude_auth_required,
     claude_permission_error, timeout, budget_exceeded, nonzero_exit, invalid_json,
     internal_error.
 
     workspace_root: absolute path to the repo to operate in; if omitted, the
     server uses the client's first MCP root, else its own cwd (see meta.workspace_source).
-    Adds error code: invalid_workspace_root (path missing or not absolute).
+    Adds error codes: invalid_workspace_root (path missing or not absolute),
+    workspace_outside_roots (explicit path outside negotiated roots).
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
-        meta = _meta("", "inherit", "toolless", 0, 0, None)
-        return _result(_err(ws_err,
-                       f"workspace_root '{workspace_root}' is not an existing absolute directory.",
-                       "Pass workspace_root as an absolute path to an existing directory, or "
-                       "configure an MCP root.", meta, offending="workspace_root"))
+        return _result(_workspace_error(ws_err, workspace_root))
     # Validate options BEFORE touching git, so bad config isn't masked by git errors.
     r, err = _resolve(config_mode, access, model, max_budget_usd, timeout_seconds,
                       detail, cwd, scope=scope, base=base, workspace_source=ws_source,
@@ -383,20 +428,18 @@ async def claude_adversarial_review(
     enum params (config_mode, access, scope, detail) are rejected by the framework
     as a schema validation error BEFORE the tool runs and do NOT use the ok:false
     envelope; all other failures return ok:false. Branch on `ok` (is_error is set
-    on failure). Always possible: invalid_workspace_root. Attaching a scope adds
-    invalid_scope, invalid_base, and context_too_large to the possible error codes.
+    on failure). Always possible: invalid_workspace_root and workspace_outside_roots.
+    Attaching a scope adds invalid_scope, invalid_base, and context_too_large to
+    the possible error codes.
 
     workspace_root: absolute path to the repo to operate in; if omitted, the
     server uses the client's first MCP root, else its own cwd (see meta.workspace_source).
-    Adds error code: invalid_workspace_root (path missing or not absolute).
+    Adds error codes: invalid_workspace_root (path missing or not absolute),
+    workspace_outside_roots (explicit path outside negotiated roots).
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
-        meta = _meta("", "inherit", "toolless", 0, 0, None)
-        return _result(_err(ws_err,
-                       f"workspace_root '{workspace_root}' is not an existing absolute directory.",
-                       "Pass workspace_root as an absolute path to an existing directory, or "
-                       "configure an MCP root.", meta, offending="workspace_root"))
+        return _result(_workspace_error(ws_err, workspace_root))
     r, err = _resolve(config_mode, access, model, max_budget_usd, timeout_seconds,
                       detail, cwd, scope=scope, base=base, workspace_source=ws_source,
                       effort=effort)
@@ -439,7 +482,7 @@ async def claude_adversarial_review(
 # Starting a background job commits to spend (the job runs to completion or its
 # budget cap even if never polled), but returns immediately without blocking.
 _ASYNC_START_ANNOTATIONS = {
-    "readOnlyHint": True, "openWorldHint": True,
+    "readOnlyHint": False, "openWorldHint": True,
     "destructiveHint": False, "idempotentHint": False,
 }
 
@@ -468,7 +511,7 @@ async def claude_review_changes_async(
     {ok, job_id, status:"running", ...} right away; the review keeps running
     detached. Poll claude_job_status(job_id), then claude_job_result(job_id) once
     status=done. Use this for large diffs or when you want to keep working while
-    Claude reviews. Paid (commits to spend) + read-only. The diff is gathered now,
+    Claude reviews. Paid (commits to spend) + creates local job state. The diff is gathered now,
     with the same secret redaction and budget cap as the synchronous tool.
 
     The job is bounded by max_budget_usd and a wall-clock deadline
@@ -479,11 +522,7 @@ async def claude_review_changes_async(
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
-        meta = _meta("", "inherit", "toolless", 0, 0, None)
-        return _result(_err(ws_err,
-                       f"workspace_root '{workspace_root}' is not an existing absolute directory.",
-                       "Pass workspace_root as an absolute path to an existing directory, or "
-                       "configure an MCP root.", meta, offending="workspace_root"))
+        return _result(_workspace_error(ws_err, workspace_root))
     r, err = _resolve(config_mode, access, model, max_budget_usd, None,
                       detail, cwd, scope=scope, base=base, workspace_source=ws_source,
                       effort=effort)
@@ -524,13 +563,15 @@ async def claude_review_changes_async(
     started = JobStarted(
         job_id=job_id, kind="claude_review_changes", started_at=started_at,
         deadline_seconds=job_timeout,
+        poll_after_ms=jobs.poll_after_ms(),
+        ttl_seconds=jobs.ttl_seconds(),
         meta=_meta(cwd, r.config_mode, r.access, job_timeout, 0, None, scope, base,
                    workspace_source=ws_source),
     )
     return _result(started.model_dump(mode="json", exclude_none=True))
 
 
-@mcp.tool(annotations=_STATUS_ANNOTATIONS, title="Background job status",
+@mcp.tool(annotations=_FREE_READ_ANNOTATIONS, title="Background job status",
           output_schema=JOB_STATUS_SCHEMA)
 async def claude_job_status(
     job_id: Annotated[str, Field(description="A job_id from an *_async tool.")],
@@ -548,10 +589,7 @@ async def claude_job_status(
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
-        meta = _meta("", "inherit", "toolless", 0, 0, None)
-        return _result(_err(ws_err, "workspace_root is not an existing absolute directory.",
-                       "Pass an absolute path or configure an MCP root.", meta,
-                       offending="workspace_root"))
+        return _result(_workspace_error(ws_err, workspace_root))
     data = await anyio.to_thread.run_sync(lambda: jobs.status(cwd, job_id))
     if data is None:
         meta = _meta(cwd, "inherit", "toolless", 0, 0, None, workspace_source=ws_source)
@@ -561,12 +599,10 @@ async def claude_job_status(
     return _result(data)
 
 
-@mcp.tool(annotations=_STATUS_ANNOTATIONS, title="Background job result",
+@mcp.tool(annotations=_FREE_READ_ANNOTATIONS, title="Background job result",
           output_schema=RESULT_SCHEMA)
 async def claude_job_result(
     job_id: Annotated[str, Field(description="A job_id from an *_async tool.")],
-    consume: Annotated[bool, Field(
-        description="Delete the job record after returning the result.")] = False,
     workspace_root: Annotated[Optional[str], Field(
         description="Workspace the job belongs to (defaults like the async tools).")] = None,
     ctx: Context = None,
@@ -577,17 +613,14 @@ async def claude_job_result(
     confidence, findings, meta.cost_usd, ...), with meta.job_id set — reuse your
     existing result parser. If the job is not yet done it returns an ok:false
     error: job_running (poll and retry), job_cancelled, job_timeout, or job_failed;
-    job_not_found if the id is unknown. Pass consume=true to delete the record once
-    you have the result.
+    job_not_found if the id is unknown. Call claude_job_consume_result to fetch
+    and delete a completed record.
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
-        meta = _meta("", "inherit", "toolless", 0, 0, None)
-        return _result(_err(ws_err, "workspace_root is not an existing absolute directory.",
-                       "Pass an absolute path or configure an MCP root.", meta,
-                       offending="workspace_root"))
+        return _result(_workspace_error(ws_err, workspace_root))
     payload, found = await anyio.to_thread.run_sync(
-        lambda: jobs.result(cwd, job_id, consume))
+        lambda: jobs.result(cwd, job_id, False))
     if not found:
         meta = _meta(cwd, "inherit", "toolless", 0, 0, None, workspace_source=ws_source)
         return _result(_err("job_not_found", f"No job '{job_id}' in this workspace.",
@@ -596,7 +629,35 @@ async def claude_job_result(
     return _result(payload)
 
 
-@mcp.tool(annotations=_STATUS_ANNOTATIONS, title="Cancel background job",
+@mcp.tool(annotations=_LOCAL_MUTATION_ANNOTATIONS, title="Consume background job result",
+          output_schema=RESULT_SCHEMA)
+async def claude_job_consume_result(
+    job_id: Annotated[str, Field(description="A job_id from an *_async tool.")],
+    workspace_root: Annotated[Optional[str], Field(
+        description="Workspace the job belongs to (defaults like the async tools).")] = None,
+    ctx: Context = None,
+) -> ToolResult:
+    """Fetch a finished background job's review and delete the job record.
+
+    Returns the same envelope as claude_job_result, with meta.job_id set, then
+    removes the stored job record once the finished result has been returned.
+    This tool changes local job state and is not idempotent. Non-done jobs return
+    the same ok:false lifecycle errors as claude_job_result and are not deleted.
+    """
+    cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
+    if ws_err:
+        return _result(_workspace_error(ws_err, workspace_root))
+    payload, found = await anyio.to_thread.run_sync(
+        lambda: jobs.result(cwd, job_id, True))
+    if not found:
+        meta = _meta(cwd, "inherit", "toolless", 0, 0, None, workspace_source=ws_source)
+        return _result(_err("job_not_found", f"No job '{job_id}' in this workspace.",
+                       "Check the job_id, or start a new job; records expire after the TTL.",
+                       meta, offending="job_id"))
+    return _result(payload)
+
+
+@mcp.tool(annotations=_LOCAL_MUTATION_ANNOTATIONS, title="Cancel background job",
           output_schema=JOB_STATUS_SCHEMA)
 async def claude_job_cancel(
     job_id: Annotated[str, Field(description="A job_id from an *_async tool.")],
@@ -612,10 +673,7 @@ async def claude_job_cancel(
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
-        meta = _meta("", "inherit", "toolless", 0, 0, None)
-        return _result(_err(ws_err, "workspace_root is not an existing absolute directory.",
-                       "Pass an absolute path or configure an MCP root.", meta,
-                       offending="workspace_root"))
+        return _result(_workspace_error(ws_err, workspace_root))
     data = await anyio.to_thread.run_sync(lambda: jobs.cancel(cwd, job_id))
     if data is None:
         meta = _meta(cwd, "inherit", "toolless", 0, 0, None, workspace_source=ws_source)
@@ -625,7 +683,7 @@ async def claude_job_cancel(
     return _result(data)
 
 
-@mcp.tool(annotations=_STATUS_ANNOTATIONS, title="Claude CLI status & defaults",
+@mcp.tool(annotations=_FREE_READ_ANNOTATIONS, title="Claude CLI status & defaults",
           output_schema=STATUS_SCHEMA)
 def claude_status() -> ToolResult:
     """Report whether `claude` is installed/usable, which config modes are available,
@@ -679,7 +737,7 @@ def claude_status() -> ToolResult:
     return _result(status.model_dump(mode="json", exclude_none=True))
 
 
-@mcp.tool(annotations=_STATUS_ANNOTATIONS, title="cc-plugin-codex capabilities",
+@mcp.tool(annotations=_FREE_READ_ANNOTATIONS, title="cc-plugin-codex capabilities",
           output_schema=CAPABILITIES_SCHEMA)
 def cc_codex_capabilities() -> ToolResult:
     """Return this server's contract as structured data: tool inventory, modes,
@@ -697,7 +755,8 @@ def cc_codex_capabilities() -> ToolResult:
         paid_tools=["claude_ask", "claude_review_changes", "claude_adversarial_review",
                     "claude_review_changes_async"],
         free_tools=["claude_status", "cc_codex_capabilities", "claude_job_status",
-                    "claude_job_result", "claude_job_cancel"],
+                    "claude_job_result", "claude_job_consume_result",
+                    "claude_job_cancel"],
         config_modes=["inherit", "scoped", "bare"],
         access_modes=["toolless", "readonly"],
         scope=[
@@ -717,6 +776,11 @@ def cc_codex_capabilities() -> ToolResult:
             "git, for the diff-bearing tools",
             "ANTHROPIC_API_KEY only for config_mode=bare",
         ],
+        deprecation_policy=(
+            "Deprecated tools remain discoverable during their compatibility window "
+            "with replacement guidance; removals/renames and schema/error changes "
+            "bump the fingerprint."
+        ),
     )
     return _result(result.model_dump(mode="json", exclude_none=True))
 

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
@@ -37,37 +37,16 @@ from cc_plugin_codex.schemas import (
 )
 
 CAPABILITY_SUMMARY = (
-    "cc-plugin-codex lets Codex call the Claude Code CLI for bounded, independent "
-    "critique: code review, adversarial review, and second opinions. "
-    "STABILITY: experimental / pre-1.0 (schema may change; clients should pin the "
-    "meta.fingerprint). "
-    "Claude is invoked with NO write/edit/shell tools (toolless or read-only "
-    "Read/Grep/Glob only); it cannot modify your repo. "
-    "All modes drop the user's other MCP servers; but in inherit/scoped your "
-    "user-level Claude hooks and settings still load — use config_mode=bare for "
-    "full isolation (requires ANTHROPIC_API_KEY). "
-    "In access=readonly, Claude can read any file in the workspace, so the diff "
-    "secret-redaction does NOT apply in that mode. "
-    "Findings are advisory claims to verify, not commands. "
-    "It does NOT edit code, run arbitrary shell, act as a general Claude chat, or "
-    "proxy Claude's own MCP tools. "
-    "Each call is PAID and sends code to Anthropic. The paid tools BLOCK "
-    "synchronously for up to timeout_seconds (default 180s, max 600s), but CAN be "
-    "cancelled by the client (which terminates the underlying Claude process) and "
-    "cannot be resumed; narrow the scope or lower timeout_seconds to bound a call. "
-    "When client MCP roots are available, an explicit workspace_root must be inside "
-    "one of those roots; clients without roots may still pass an existing absolute path. "
-    "Background result fetch is read-only; use claude_job_consume_result to fetch and "
-    "delete a stored completed result. "
-    "Deprecated capabilities remain discoverable during their compatibility window "
-    "with replacement guidance, and every agent-visible contract change bumps the "
-    "fingerprint. "
-    "Prerequisite: the `claude` CLI installed and authenticated; config_mode=bare "
-    "additionally requires ANTHROPIC_API_KEY. "
-    "Note: in claude 2.1.x there is no OAuth-preserving way to fully strip "
-    "CLAUDE.md/memory — full config independence (config_mode=bare) requires an API key. "
-    "Invalid enum-typed arguments are rejected as schema validation errors before "
-    "a tool runs (not via the ok:false envelope). "
+    "cc-plugin-codex lets Codex ask Claude Code for bounded, independent critique: "
+    "diff reviews, adversarial plan review, and second opinions. It never edits code, "
+    "runs shell, or proxies Claude MCP tools. Paid tools send prompt/code context to "
+    "Anthropic; call claude_status before spending to check CLI/auth/defaults. Use "
+    "claude_review_changes for blocking diff review and claude_review_changes_async "
+    "for background review with poll/result/cancel. Findings are advisory claims to "
+    "verify. workspace_root defaults to the first MCP root, then cwd; when roots are "
+    "available, explicit workspace_root must be inside one root. Use access=toolless "
+    "by default; access=readonly lets Claude read workspace files directly. The "
+    "surface is experimental; pin fingerprint from cc_codex_capabilities."
 )
 
 mcp = FastMCP(name="cc-plugin-codex", instructions=CAPABILITY_SUMMARY)
@@ -285,36 +264,24 @@ async def claude_ask(
         "the server uses the client's first MCP root, else its own cwd.")] = None,
     config_mode: Annotated[Optional[ConfigMode], Field(description="inherit|scoped|bare")] = None,
     access: Annotated[Optional[Access], Field(description="toolless|readonly")] = None,
-    model: Optional[str] = None,
+    model: Annotated[Optional[str], Field(
+        description="Claude model override; omit for configured default.")] = None,
     effort: Annotated[Optional[Effort], Field(
         description="Reasoning effort: low|medium|high|xhigh|max. "
         "Raise for high-stakes reviews; omit to use the server default.")] = None,
-    max_budget_usd: Optional[float] = None,
-    timeout_seconds: Optional[int] = None,
+    max_budget_usd: Annotated[Optional[float], Field(
+        description="Per-call Claude spend cap; clamped by server limits.")] = None,
+    timeout_seconds: Annotated[Optional[int], Field(
+        description="Sync call timeout; omit for configured default.")] = None,
     detail: Annotated[Detail, Field(description="summary|full")] = "summary",
     ctx: Context = None,
 ) -> ToolResult:
-    """Ask Claude for an independent second opinion or recommendation.
+    """Ask Claude for a free-form second opinion.
 
-    Use for a free-form question where you want a fresh, evidence-based view.
-    Example: claude_ask(prompt="Is optimistic locking safe for this counter?").
-    Paid + sends your prompt to Anthropic. Read-only. Blocks up to timeout_seconds;
-    can be cancelled by the client (terminates the Claude process), not resumed.
-    Invalid values for typed enum params
-    (config_mode, access, detail) are rejected by the framework as a schema
-    validation error BEFORE the tool runs and do NOT use the ok:false envelope; all
-    other failures return ok:false. Errors come back as
-    {"ok": false, "error": {code, message, repair}} with is_error set — branch on
-    `ok`. Possible error codes: unsupported_config_mode, unsupported_access,
-    api_key_missing, api_key_invalid, invalid_workspace_root, workspace_outside_roots,
-    claude_not_found, claude_auth_required,
-    claude_permission_error, timeout, budget_exceeded, nonzero_exit, invalid_json,
-    internal_error.
-
-    workspace_root: absolute path to the repo to operate in; if omitted, the
-    server uses the client's first MCP root, else its own cwd (see meta.workspace_source).
-    Adds error codes: invalid_workspace_root (path missing or not absolute),
-    workspace_outside_roots (explicit path outside negotiated roots).
+    Use when the task is a question or design choice, not a git diff review or
+    adversarial attack. Paid external call; read-only; blocks up to
+    timeout_seconds and can be cancelled but not resumed. Returns structured
+    ok:true findings or ok:false repair errors.
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
@@ -339,36 +306,24 @@ async def claude_review_changes(
         "the server uses the client's first MCP root, else its own cwd.")] = None,
     config_mode: Annotated[Optional[ConfigMode], Field(description="inherit|scoped|bare")] = None,
     access: Annotated[Optional[Access], Field(description="toolless|readonly")] = None,
-    model: Optional[str] = None,
+    model: Annotated[Optional[str], Field(
+        description="Claude model override; omit for configured default.")] = None,
     effort: Annotated[Optional[Effort], Field(
         description="Reasoning effort: low|medium|high|xhigh|max. "
         "Raise for high-stakes reviews; omit to use the server default.")] = None,
-    max_budget_usd: Optional[float] = None,
-    timeout_seconds: Optional[int] = None,
+    max_budget_usd: Annotated[Optional[float], Field(
+        description="Per-call Claude spend cap; clamped by server limits.")] = None,
+    timeout_seconds: Annotated[Optional[int], Field(
+        description="Sync call timeout; omit for configured default.")] = None,
     detail: Annotated[Detail, Field(description="summary|full")] = "summary",
     ctx: Context = None,
 ) -> ToolResult:
-    """Have Claude review a git diff for correctness, regressions, security, tests.
+    """Review a git diff with Claude and wait for the result.
 
-    scope: working_tree (unstaged), staged, or branch (diff base...HEAD).
-    Example: claude_review_changes(scope="working_tree", focus="security").
-    The server gathers the diff itself (Claude gets no shell). Paid + read-only.
-    Blocks up to timeout_seconds; can be cancelled by the client (terminates the
-    Claude process), not resumed. Invalid values
-    for typed enum params (config_mode, access, scope, detail) are rejected by the
-    framework as a schema validation error BEFORE the tool runs and do NOT use the
-    ok:false envelope; all other failures return ok:false. Branch on `ok` (is_error
-    is set on failure); error codes: unsupported_config_mode, unsupported_access,
-    api_key_missing, api_key_invalid, invalid_workspace_root, workspace_outside_roots,
-    invalid_scope, invalid_base,
-    context_too_large, claude_not_found, claude_auth_required,
-    claude_permission_error, timeout, budget_exceeded, nonzero_exit, invalid_json,
-    internal_error.
-
-    workspace_root: absolute path to the repo to operate in; if omitted, the
-    server uses the client's first MCP root, else its own cwd (see meta.workspace_source).
-    Adds error codes: invalid_workspace_root (path missing or not absolute),
-    workspace_outside_roots (explicit path outside negotiated roots).
+    Use for correctness, regression, security, or test-coverage review of
+    working_tree, staged, or branch diff. Paid external call; read-only; blocks up
+    to timeout_seconds and can be cancelled but not resumed. For long reviews, use
+    claude_review_changes_async.
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
@@ -412,38 +367,30 @@ async def claude_adversarial_review(
     target: Annotated[str, Field(description="The plan/claim/decision to attack.")],
     evidence: Annotated[Optional[str], Field(description="Supporting evidence.")] = None,
     scope: Annotated[Optional[Scope], Field(description="Optionally attach a diff: working_tree|staged|branch")] = None,
-    base: str = "main",
+    base: Annotated[str, Field(
+        description="Base ref for branch diff when scope=branch.")] = "main",
     workspace_root: Annotated[Optional[str], Field(
         description="Absolute path to the repo/workspace to operate in. If omitted, "
         "the server uses the client's first MCP root, else its own cwd.")] = None,
     config_mode: Annotated[Optional[ConfigMode], Field(description="inherit|scoped|bare")] = None,
     access: Annotated[Optional[Access], Field(description="toolless|readonly")] = None,
-    model: Optional[str] = None,
+    model: Annotated[Optional[str], Field(
+        description="Claude model override; omit for configured default.")] = None,
     effort: Annotated[Optional[Effort], Field(
         description="Reasoning effort: low|medium|high|xhigh|max. "
         "Raise for high-stakes reviews; omit to use the server default.")] = None,
-    max_budget_usd: Optional[float] = None,
-    timeout_seconds: Optional[int] = None,
+    max_budget_usd: Annotated[Optional[float], Field(
+        description="Per-call Claude spend cap; clamped by server limits.")] = None,
+    timeout_seconds: Annotated[Optional[int], Field(
+        description="Sync call timeout; omit for configured default.")] = None,
     detail: Annotated[Detail, Field(description="summary|full")] = "summary",
     ctx: Context = None,
 ) -> ToolResult:
-    """Have Claude attack a plan or claim and surface the strongest counterarguments.
+    """Have Claude attack a plan, claim, or decision.
 
-    Example: claude_adversarial_review(target="We can skip locking; writes are rare.").
-    Optionally attach a diff via scope. Paid + read-only. Blocks up to
-    timeout_seconds; can be cancelled by the client (terminates the Claude process),
-    not resumed. Invalid values for typed
-    enum params (config_mode, access, scope, detail) are rejected by the framework
-    as a schema validation error BEFORE the tool runs and do NOT use the ok:false
-    envelope; all other failures return ok:false. Branch on `ok` (is_error is set
-    on failure). Always possible: invalid_workspace_root and workspace_outside_roots.
-    Attaching a scope adds invalid_scope, invalid_base, and context_too_large to
-    the possible error codes.
-
-    workspace_root: absolute path to the repo to operate in; if omitted, the
-    server uses the client's first MCP root, else its own cwd (see meta.workspace_source).
-    Adds error codes: invalid_workspace_root (path missing or not absolute),
-    workspace_outside_roots (explicit path outside negotiated roots).
+    Use to surface counterarguments and failure modes. Include evidence text, and
+    optionally attach a git diff with scope/base. Paid external call; read-only;
+    blocks up to timeout_seconds and can be cancelled but not resumed.
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
@@ -506,27 +453,21 @@ async def claude_review_changes_async(
         "the server uses the client's first MCP root, else its own cwd.")] = None,
     config_mode: Annotated[Optional[ConfigMode], Field(description="inherit|scoped|bare")] = None,
     access: Annotated[Optional[Access], Field(description="toolless|readonly")] = None,
-    model: Optional[str] = None,
+    model: Annotated[Optional[str], Field(
+        description="Claude model override; omit for configured default.")] = None,
     effort: Annotated[Optional[Effort], Field(
         description="Reasoning effort: low|medium|high|xhigh|max.")] = None,
-    max_budget_usd: Optional[float] = None,
+    max_budget_usd: Annotated[Optional[float], Field(
+        description="Per-call Claude spend cap; clamped by server limits.")] = None,
     detail: Annotated[Detail, Field(description="summary|full")] = "summary",
     ctx: Context = None,
 ) -> ToolResult:
-    """Launch a Claude diff review as a BACKGROUND job and return immediately.
+    """Launch a git diff review in the background and return a job_id.
 
-    Unlike claude_review_changes (which blocks), this returns a job handle
-    {ok, job_id, status:"running", ...} right away; the review keeps running
-    detached. Poll claude_job_status(job_id), then claude_job_result(job_id) once
-    status=done. Use this for large diffs or when you want to keep working while
-    Claude reviews. Paid (commits to spend) + creates local job state. The diff is gathered now,
-    with the same secret redaction and budget cap as the synchronous tool.
-
-    The job is bounded by max_budget_usd and a wall-clock deadline
-    (CC_PLUGIN_CODEX_JOB_MAX_SECONDS, default 1800s) enforced on the next status
-    poll. timeout_seconds does not apply (there is no blocking call to time out).
-    Error codes mirror claude_review_changes for the launch phase (e.g.
-    invalid_scope, invalid_base, context_too_large, unsupported_config_mode).
+    Use when a diff review may outlive the current turn. Paid external call;
+    creates local job state and cannot be resumed if cancelled. Poll with
+    claude_job_status, read with claude_job_result, delete after reading with
+    claude_job_consume_result, or stop with claude_job_cancel.
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
@@ -587,13 +528,11 @@ async def claude_job_status(
         description="Workspace the job belongs to (defaults like the async tools).")] = None,
     ctx: Context = None,
 ) -> ToolResult:
-    """Report a background job's lifecycle state (free; no Claude call).
+    """Check a background review job without fetching the full result.
 
-    Returns {ok, job_id, status, elapsed_ms, result_available, cost_usd?} where
-    status is running|done|failed|cancelled|timeout. Call claude_job_result once
-    result_available is true. A running job past its deadline is stopped and
-    reported as timeout here. Returns job_not_found if the id is unknown (or its
-    record was cleaned up after the TTL).
+    Use after claude_review_changes_async. Returns status, elapsed time,
+    result_available, polling hints, and cost when available. If
+    result_available is true, call claude_job_result.
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
@@ -615,14 +554,11 @@ async def claude_job_result(
         description="Workspace the job belongs to (defaults like the async tools).")] = None,
     ctx: Context = None,
 ) -> ToolResult:
-    """Fetch a finished background job's review (free; no new Claude call).
+    """Fetch a finished background review without deleting the job record.
 
-    On success returns the SAME envelope as the synchronous tools (ok, verdict,
-    confidence, findings, meta.cost_usd, ...), with meta.job_id set — reuse your
-    existing result parser. If the job is not yet done it returns an ok:false
-    error: job_running (poll and retry), job_cancelled, job_timeout, or job_failed;
-    job_not_found if the id is unknown. Call claude_job_consume_result to fetch
-    and delete a completed record.
+    Use when claude_job_status reports result_available=true. Returns the same
+    structured review envelope as claude_review_changes, with meta.job_id set. To
+    fetch and delete the stored record, use claude_job_consume_result.
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
@@ -645,12 +581,11 @@ async def claude_job_consume_result(
         description="Workspace the job belongs to (defaults like the async tools).")] = None,
     ctx: Context = None,
 ) -> ToolResult:
-    """Fetch a finished background job's review and delete the job record.
+    """Fetch a finished background review and delete the stored job record.
 
-    Returns the same envelope as claude_job_result, with meta.job_id set, then
-    removes the stored job record once the finished result has been returned.
-    This tool changes local job state and is not idempotent. Non-done jobs return
-    the same ok:false lifecycle errors as claude_job_result and are not deleted.
+    Use only when you no longer need to poll or re-read the job. Returns the same
+    structured envelope as claude_job_result, then deletes completed job state.
+    Non-done jobs are not deleted.
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
@@ -673,11 +608,11 @@ async def claude_job_cancel(
         description="Workspace the job belongs to (defaults like the async tools).")] = None,
     ctx: Context = None,
 ) -> ToolResult:
-    """Stop a running background job (free; terminates the Claude process).
+    """Cancel a running background review job.
 
-    Kills the detached Claude process and marks the job cancelled; a cancelled job
-    cannot be resumed. Returns the resulting JobStatus, or job_not_found. Already
-    terminal jobs are returned unchanged.
+    Use to stop a job from claude_review_changes_async. Terminates the Claude
+    process and marks the job cancelled; cancelled jobs cannot be resumed.
+    Already-terminal jobs are returned unchanged.
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
@@ -694,13 +629,10 @@ async def claude_job_cancel(
 @mcp.tool(annotations=_FREE_READ_ANNOTATIONS, title="Claude CLI status & defaults",
           output_schema=STATUS_SCHEMA)
 def claude_status() -> ToolResult:
-    """Report whether `claude` is installed/usable, which config modes are available,
-    and the resolved defaults a no-argument paid call would use.
+    """Check Claude CLI readiness and resolved defaults before spending.
 
-    Read-only and free (makes no Claude call). Use this first if other tools fail.
-    The resolved_defaults block reflects the CC_PLUGIN_CODEX_* environment (after
-    clamping), so an agent can predict a call's config_mode/access/budget/timeout
-    before spending. Example: claude_status().
+    Free and read-only. Use first when unsure whether paid tools can run, or to
+    inspect config_mode/access/model/effort/budget/timeout defaults.
     """
     found = shutil.which("claude") is not None
     version = None
@@ -748,12 +680,11 @@ def claude_status() -> ToolResult:
 @mcp.tool(annotations=_FREE_READ_ANNOTATIONS, title="cc-plugin-codex capabilities",
           output_schema=CAPABILITIES_SCHEMA)
 def cc_codex_capabilities() -> ToolResult:
-    """Return this server's contract as structured data: tool inventory, modes,
-    scope/negative-scope, prerequisites, and the schema fingerprint.
+    """Return the compact capability contract for this server.
 
-    Free and read-only (makes no Claude call). Clients that cannot browse MCP
-    resources can read the same contract the cc-plugin-codex://capabilities
-    resource carries as prose. Pin `fingerprint` to detect schema changes.
+    Free and read-only. Call first when unsure which tool to use. Includes tool
+    inventory, scope/negative-scope, prerequisites, modes, deprecation policy, and
+    fingerprint.
     """
     result = CapabilitiesResult(
         name="cc-plugin-codex",

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
@@ -15,6 +15,7 @@ from fastmcp import Context, FastMCP
 from fastmcp.tools.tool import ToolResult
 from pydantic import Field
 
+from cc_plugin_codex import __version__
 from cc_plugin_codex.claude import (
     auth_status, build_command, classify_failure, run_claude_async,
 )
@@ -688,7 +689,7 @@ def cc_codex_capabilities() -> ToolResult:
     """
     result = CapabilitiesResult(
         name="cc-plugin-codex",
-        version="0.1.0",
+        version=__version__,
         transport="stdio",
         stability="experimental",
         paid_tools=["claude_ask", "claude_review_changes", "claude_adversarial_review",

--- a/plugins/cc-plugin-codex/tests/test_claude.py
+++ b/plugins/cc-plugin-codex/tests/test_claude.py
@@ -78,7 +78,7 @@ def test_classify_not_logged_in():
 def test_classify_invalid_api_key():
     run = ClaudeRun(stdout="", stderr="Invalid API key · Fix external API key",
                     exit_code=1, elapsed_ms=5, timed_out=False)
-    assert classify_failure(run).code == "api_key_required"
+    assert classify_failure(run).code == "api_key_invalid"
 
 
 def test_classify_timeout():

--- a/plugins/cc-plugin-codex/tests/test_context.py
+++ b/plugins/cc-plugin-codex/tests/test_context.py
@@ -38,6 +38,8 @@ def test_size_cap_truncates(git_repo, monkeypatch):
     res = gather_context(str(git_repo), scope="working_tree", base="main")
     assert res.truncated is True
     assert res.truncation_hint
+    assert "scope=staged" in res.truncation_hint
+    assert "review specific files" not in res.truncation_hint
 
 
 def test_stage_env_file_redacted(git_repo):

--- a/plugins/cc-plugin-codex/tests/test_jobs.py
+++ b/plugins/cc-plugin-codex/tests/test_jobs.py
@@ -70,6 +70,9 @@ def test_job_done_returns_normalized_result(tmp_path):
     # reports the deadline window the job started with (1800s), not a live env read.
     assert st["fingerprint"]
     assert st["deadline_seconds"] == 1800
+    assert st["poll_after_ms"] == 1000
+    assert st["ttl_seconds"] == 86400
+    assert st["expires_at"]
 
     payload, found = jobs.result(cwd, job_id)
     assert found is True
@@ -132,6 +135,15 @@ def test_terminal_job_reaped_after_ttl(tmp_path, monkeypatch):
     monkeypatch.setenv("CC_PLUGIN_CODEX_JOB_TTL", "0")
     time.sleep(0.02)
     assert jobs.status(cwd, job_id) is None  # reaped
+
+
+def test_result_preserves_record_by_default(tmp_path):
+    cwd = str(tmp_path)
+    job_id, _ = jobs.start_job(_emit_cmd(), cwd, _cfg())
+    _await_done(cwd, job_id)
+    payload, found = jobs.result(cwd, job_id)
+    assert found is True and payload["ok"] is True
+    assert jobs.status(cwd, job_id)["status"] == "done"
 
 
 def test_consume_deletes_record(tmp_path):

--- a/plugins/cc-plugin-codex/tests/test_schemas.py
+++ b/plugins/cc-plugin-codex/tests/test_schemas.py
@@ -38,7 +38,7 @@ def test_success_result_has_next_steps():
 
 
 def test_fingerprint_value():
-    assert FINGERPRINT == "cc-plugin-codex/0.1/schema-7"
+    assert FINGERPRINT == "cc-plugin-codex/0.1/schema-8"
 
 
 def test_success_result_dump_omits_none():

--- a/plugins/cc-plugin-codex/tests/test_schemas.py
+++ b/plugins/cc-plugin-codex/tests/test_schemas.py
@@ -38,7 +38,7 @@ def test_success_result_has_next_steps():
 
 
 def test_fingerprint_value():
-    assert FINGERPRINT == "cc-plugin-codex/0.1/schema-6"
+    assert FINGERPRINT == "cc-plugin-codex/0.1/schema-7"
 
 
 def test_success_result_dump_omits_none():

--- a/plugins/cc-plugin-codex/tests/test_server.py
+++ b/plugins/cc-plugin-codex/tests/test_server.py
@@ -160,13 +160,28 @@ async def test_capability_summary_declares_tier_and_blocking():
     summary = CAPABILITY_SUMMARY.lower()
     assert "experimental" in summary
     assert "cancel" in summary
+    assert len(CAPABILITY_SUMMARY) < 900
 
 
-async def test_review_tool_documents_scope_codes_ask_does_not():
-    # F6: scope/diff codes belong only on diff-bearing tools.
+async def test_tool_descriptions_are_concise_and_disambiguating():
     tools = await _tools_by_name()
-    assert "invalid_scope" in tools["claude_review_changes"].description
-    assert "invalid_scope" not in tools["claude_ask"].description
+    for tool in tools.values():
+        assert len(tool.description or "") <= 450, tool.name
+    assert "question or design choice" in tools["claude_ask"].description
+    assert "git diff" in tools["claude_review_changes"].description
+    assert "background" in tools["claude_review_changes_async"].description
+    assert "without deleting" in tools["claude_job_result"].description
+    assert "delete the stored job record" in tools["claude_job_consume_result"].description
+
+
+async def test_common_optional_params_are_described():
+    tools = await _tools_by_name()
+    for name in ("claude_ask", "claude_review_changes", "claude_adversarial_review"):
+        props = tools[name].inputSchema["properties"]
+        assert props["model"]["description"]
+        assert props["max_budget_usd"]["description"]
+        assert props["timeout_seconds"]["description"]
+    assert tools["claude_adversarial_review"].inputSchema["properties"]["base"]["description"]
 
 
 async def test_status_reports_config_modes(monkeypatch):
@@ -184,7 +199,7 @@ async def test_claude_ask_returns_normalized(fake_claude):
     data = structured(result)
     assert data["ok"] is True
     assert data["verdict"] == "concerns"
-    assert data["meta"]["fingerprint"] == "cc-plugin-codex/0.1/schema-7"
+    assert data["meta"]["fingerprint"] == "cc-plugin-codex/0.1/schema-8"
 
 
 async def test_invalid_enum_param_rejected_by_schema(fake_claude):
@@ -329,13 +344,12 @@ async def test_adversarial_invalid_scope_param_rejected_by_schema(fake_claude, m
     assert "working_tree" in str(exc.value)
 
 
-async def test_paid_docstrings_note_schema_validation_class(fake_claude):
-    # F2: docstrings must disclose that invalid enum values are rejected by the
-    # framework (a validation error), separate from the ok:false envelope.
+async def test_paid_tool_descriptions_do_not_inline_error_catalogs(fake_claude):
     tools = await _tools_by_name()
     for name in PAID_TOOLS:
         desc = tools[name].description.lower()
-        assert "schema" in desc or "validation error" in desc, name
+        assert "possible error codes" not in desc, name
+        assert "validation error" not in desc, name
 
 
 async def test_adversarial_bad_base_ref_is_structured_error(fake_claude, monkeypatch, git_repo):
@@ -540,7 +554,7 @@ async def test_capabilities_tool_returns_structured_contract():
     async with Client(mcp) as client:
         result = await client.call_tool("cc_codex_capabilities", {})
     data = structured(result)
-    assert data["fingerprint"] == "cc-plugin-codex/0.1/schema-7"
+    assert data["fingerprint"] == "cc-plugin-codex/0.1/schema-8"
     assert data["transport"] == "stdio"
     assert set(data["paid_tools"]) == {
         "claude_ask", "claude_review_changes", "claude_adversarial_review",

--- a/plugins/cc-plugin-codex/tests/test_server.py
+++ b/plugins/cc-plugin-codex/tests/test_server.py
@@ -382,10 +382,10 @@ async def test_job_tools_declare_state_hints():
     tools = await _tools_by_name()
     assert tools["claude_review_changes_async"].annotations.readOnlyHint is False
     assert tools["claude_review_changes_async"].annotations.idempotentHint is False
-    assert tools["claude_job_status"].annotations.readOnlyHint is True
-    assert tools["claude_job_status"].annotations.idempotentHint is True
-    assert tools["claude_job_result"].annotations.readOnlyHint is True
-    assert tools["claude_job_result"].annotations.idempotentHint is True
+    assert tools["claude_job_status"].annotations.readOnlyHint is False
+    assert tools["claude_job_status"].annotations.idempotentHint is False
+    assert tools["claude_job_result"].annotations.readOnlyHint is False
+    assert tools["claude_job_result"].annotations.idempotentHint is False
     assert tools["claude_job_consume_result"].annotations.readOnlyHint is False
     assert tools["claude_job_consume_result"].annotations.idempotentHint is False
     assert tools["claude_job_cancel"].annotations.readOnlyHint is False

--- a/plugins/cc-plugin-codex/tests/test_server.py
+++ b/plugins/cc-plugin-codex/tests/test_server.py
@@ -37,11 +37,13 @@ async def test_first_root_skips_non_file_uris():
     assert await _first_root(ctx) == "/ok"
 
 
-async def test_resolve_workspace_param_beats_roots(tmp_path):
-    ctx = _FakeRoots(["file:///should/not/win"])
-    path, err, source = await _resolve_workspace(str(tmp_path), ctx)
+async def test_resolve_workspace_param_inside_root_beats_root_default(tmp_path):
+    child = tmp_path / "repo"
+    child.mkdir()
+    ctx = _FakeRoots([f"file://{tmp_path}"])
+    path, err, source = await _resolve_workspace(str(child), ctx)
     assert err is None
-    assert path == str(tmp_path)
+    assert path == str(child)
     assert source == "param"
 
 
@@ -51,6 +53,29 @@ async def test_resolve_workspace_uses_roots_when_no_param(tmp_path):
     assert err is None
     assert path == str(tmp_path)
     assert source == "roots"
+
+
+async def test_resolve_workspace_param_must_be_inside_roots(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    ctx = _FakeRoots([f"file://{root}"])
+    path, err, source = await _resolve_workspace(str(outside), ctx)
+    assert path is None
+    assert err == "workspace_outside_roots"
+    assert source is None
+
+
+async def test_resolve_workspace_param_inside_roots_allowed(tmp_path):
+    root = tmp_path / "root"
+    child = root / "repo"
+    child.mkdir(parents=True)
+    ctx = _FakeRoots([f"file://{root}"])
+    path, err, source = await _resolve_workspace(str(child), ctx)
+    assert err is None
+    assert path == str(child)
+    assert source == "param"
 
 
 async def test_resolve_workspace_falls_back_to_cwd(monkeypatch, tmp_path):
@@ -159,7 +184,7 @@ async def test_claude_ask_returns_normalized(fake_claude):
     data = structured(result)
     assert data["ok"] is True
     assert data["verdict"] == "concerns"
-    assert data["meta"]["fingerprint"] == "cc-plugin-codex/0.1/schema-6"
+    assert data["meta"]["fingerprint"] == "cc-plugin-codex/0.1/schema-7"
 
 
 async def test_invalid_enum_param_rejected_by_schema(fake_claude):
@@ -200,7 +225,7 @@ async def test_bare_without_api_key_errors(fake_claude, monkeypatch):
         result = await client.call_tool(
             "claude_ask", {"prompt": "x", "config_mode": "bare"}, raise_on_error=False)
     data = structured(result)
-    assert data["error"]["code"] == "api_key_required"
+    assert data["error"]["code"] == "api_key_missing"
 
 
 async def test_success_response_carries_request_id(fake_claude):
@@ -339,6 +364,20 @@ async def test_paid_tools_declare_cost_safety_hints():
         assert ann.idempotentHint is False, name
 
 
+async def test_job_tools_declare_state_hints():
+    tools = await _tools_by_name()
+    assert tools["claude_review_changes_async"].annotations.readOnlyHint is False
+    assert tools["claude_review_changes_async"].annotations.idempotentHint is False
+    assert tools["claude_job_status"].annotations.readOnlyHint is True
+    assert tools["claude_job_status"].annotations.idempotentHint is True
+    assert tools["claude_job_result"].annotations.readOnlyHint is True
+    assert tools["claude_job_result"].annotations.idempotentHint is True
+    assert tools["claude_job_consume_result"].annotations.readOnlyHint is False
+    assert tools["claude_job_consume_result"].annotations.idempotentHint is False
+    assert tools["claude_job_cancel"].annotations.readOnlyHint is False
+    assert tools["claude_job_cancel"].annotations.idempotentHint is False
+
+
 async def test_review_uses_workspace_root_over_cwd(fake_claude, monkeypatch, git_repo, tmp_path):
     # F1: with cwd pointed at an unrelated (non-repo) dir, an explicit
     # workspace_root makes the review target the intended repo.
@@ -367,6 +406,22 @@ async def test_review_invalid_workspace_root_is_structured_error(fake_claude):
     assert data["error"]["offending_param"] == "workspace_root"
 
 
+async def test_review_workspace_outside_roots_is_structured_error(fake_claude, tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    async with Client(mcp, roots=[root.as_uri()]) as client:
+        result = await client.call_tool(
+            "claude_review_changes",
+            {"scope": "working_tree", "workspace_root": str(outside)},
+            raise_on_error=False)
+    data = structured(result)
+    assert data["ok"] is False
+    assert data["error"]["code"] == "workspace_outside_roots"
+    assert data["error"]["offending_param"] == "workspace_root"
+
+
 async def test_review_changes_async_lifecycle(monkeypatch, git_repo, tmp_path):
     # End-to-end through the MCP surface: launch async -> poll status -> get the
     # same envelope as the sync tool. build_command is replaced with a fake that
@@ -390,6 +445,8 @@ async def test_review_changes_async_lifecycle(monkeypatch, git_repo, tmp_path):
             {"scope": "working_tree", "workspace_root": str(git_repo)}))
         assert started["ok"] is True
         assert started["status"] == "running"
+        assert started["poll_after_ms"] == 1000
+        assert started["ttl_seconds"] > 0
         job_id = started["job_id"]
 
         import time as _time
@@ -400,6 +457,8 @@ async def test_review_changes_async_lifecycle(monkeypatch, git_repo, tmp_path):
                 "claude_job_status",
                 {"job_id": job_id, "workspace_root": str(git_repo)}))
             status = st["status"]
+            assert st["poll_after_ms"] == 1000
+            assert st["ttl_seconds"] > 0
             if status != "running":
                 break
             await anyio.sleep(0.05)
@@ -423,22 +482,64 @@ async def test_job_result_not_found_is_structured_error(tmp_path, monkeypatch, g
     assert data["error"]["code"] == "job_not_found"
 
 
+async def test_job_consume_result_deletes_finished_record(monkeypatch, git_repo, tmp_path):
+    import json as _json
+    import time as _time
+
+    import cc_plugin_codex.server as srv
+
+    monkeypatch.setenv("CC_PLUGIN_CODEX_STATE_DIR", str(tmp_path / "state"))
+    inner = {"summary": "ok", "verdict": "pass", "confidence": "high",
+             "findings": [], "questions": [], "assumptions": []}
+    envelope = _json.dumps({"type": "result", "subtype": "success", "is_error": False,
+                            "result": _json.dumps(inner)})
+    monkeypatch.setattr(srv, "build_command",
+                        lambda *a, **k: ["sh", "-c", "printf '%s' \"$0\"", envelope])
+
+    async with Client(mcp) as client:
+        started = structured(await client.call_tool(
+            "claude_review_changes_async",
+            {"scope": "working_tree", "workspace_root": str(git_repo)}))
+        job_id = started["job_id"]
+        deadline = _time.time() + 5
+        while _time.time() < deadline:
+            st = structured(await client.call_tool(
+                "claude_job_status",
+                {"job_id": job_id, "workspace_root": str(git_repo)}))
+            if st["status"] == "done":
+                break
+            await anyio.sleep(0.05)
+        res = structured(await client.call_tool(
+            "claude_job_consume_result",
+            {"job_id": job_id, "workspace_root": str(git_repo)}))
+        missing = structured(await client.call_tool(
+            "claude_job_status",
+            {"job_id": job_id, "workspace_root": str(git_repo)},
+            raise_on_error=False))
+
+    assert res["ok"] is True
+    assert res["meta"]["job_id"] == job_id
+    assert missing["error"]["code"] == "job_not_found"
+
+
 async def test_capabilities_tool_returns_structured_contract():
     # F7: the capability/version contract is available as structured data, not
     # only as a prose resource.
     async with Client(mcp) as client:
         result = await client.call_tool("cc_codex_capabilities", {})
     data = structured(result)
-    assert data["fingerprint"] == "cc-plugin-codex/0.1/schema-6"
+    assert data["fingerprint"] == "cc-plugin-codex/0.1/schema-7"
     assert data["transport"] == "stdio"
     assert set(data["paid_tools"]) == {
         "claude_ask", "claude_review_changes", "claude_adversarial_review",
         "claude_review_changes_async"}
     assert "claude_status" in data["free_tools"]
-    for lifecycle in ("claude_job_status", "claude_job_result", "claude_job_cancel"):
+    for lifecycle in ("claude_job_status", "claude_job_result",
+                      "claude_job_consume_result", "claude_job_cancel"):
         assert lifecycle in data["free_tools"]
     assert data["negative_scope"]            # non-empty list of what it won't do
     assert data["prerequisites"]
+    assert "fingerprint" in data["deprecation_policy"]
 
 
 async def test_paid_failure_reports_cost_on_error_meta(monkeypatch):

--- a/plugins/cc-plugin-codex/tests/test_server.py
+++ b/plugins/cc-plugin-codex/tests/test_server.py
@@ -40,7 +40,7 @@ async def test_first_root_skips_non_file_uris():
 async def test_resolve_workspace_param_inside_root_beats_root_default(tmp_path):
     child = tmp_path / "repo"
     child.mkdir()
-    ctx = _FakeRoots([f"file://{tmp_path}"])
+    ctx = _FakeRoots([tmp_path.as_uri()])
     path, err, source = await _resolve_workspace(str(child), ctx)
     assert err is None
     assert path == str(child)
@@ -48,7 +48,7 @@ async def test_resolve_workspace_param_inside_root_beats_root_default(tmp_path):
 
 
 async def test_resolve_workspace_uses_roots_when_no_param(tmp_path):
-    ctx = _FakeRoots([f"file://{tmp_path}"])
+    ctx = _FakeRoots([tmp_path.as_uri()])
     path, err, source = await _resolve_workspace(None, ctx)
     assert err is None
     assert path == str(tmp_path)
@@ -60,7 +60,7 @@ async def test_resolve_workspace_param_must_be_inside_roots(tmp_path):
     root.mkdir()
     outside = tmp_path / "outside"
     outside.mkdir()
-    ctx = _FakeRoots([f"file://{root}"])
+    ctx = _FakeRoots([root.as_uri()])
     path, err, source = await _resolve_workspace(str(outside), ctx)
     assert path is None
     assert err == "workspace_outside_roots"
@@ -71,7 +71,7 @@ async def test_resolve_workspace_param_inside_roots_allowed(tmp_path):
     root = tmp_path / "root"
     child = root / "repo"
     child.mkdir(parents=True)
-    ctx = _FakeRoots([f"file://{root}"])
+    ctx = _FakeRoots([root.as_uri()])
     path, err, source = await _resolve_workspace(str(child), ctx)
     assert err is None
     assert path == str(child)
@@ -404,6 +404,18 @@ async def test_review_invalid_workspace_root_is_structured_error(fake_claude):
     assert data["ok"] is False
     assert data["error"]["code"] == "invalid_workspace_root"
     assert data["error"]["offending_param"] == "workspace_root"
+
+
+async def test_review_invalid_root_without_param_does_not_blame_workspace_root(fake_claude, tmp_path):
+    missing = tmp_path / "missing"
+    async with Client(mcp, roots=[missing.as_uri()]) as client:
+        result = await client.call_tool(
+            "claude_review_changes", {"scope": "working_tree"}, raise_on_error=False)
+    data = structured(result)
+    assert data["ok"] is False
+    assert data["error"]["code"] == "invalid_workspace_root"
+    assert "offending_param" not in data["error"]
+    assert "workspace_root 'None'" not in data["error"]["message"]
 
 
 async def test_review_workspace_outside_roots_is_structured_error(fake_claude, tmp_path):

--- a/plugins/cc-plugin-codex/uv.lock
+++ b/plugins/cc-plugin-codex/uv.lock
@@ -158,6 +158,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "prek" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -172,6 +173,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "prek", specifier = ">=0.4.4" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "ruff", specifier = ">=0.15.15" },
@@ -795,6 +797,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prek"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/13/3d71b3adbf385f7dc7fb6e16d6e25421fd8398b45d8f8410a328bf22bd3f/prek-0.4.4.tar.gz", hash = "sha256:4ec5771153d158a0e4473933b7fd9b51e1b1f57f2df50aeb7560ea6812226dc5", size = 470641, upload-time = "2026-06-04T07:26:07.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/9f/68a577888edf7f2647a652b02899508ccd84e57ce1f79c51a44edfd308d7/prek-0.4.4-py3-none-linux_armv6l.whl", hash = "sha256:23cfd96a25de1c93e3c43c746643b80489e3b2fa49ca9c0ffd6022e51535c900", size = 5550271, upload-time = "2026-06-04T07:26:17.834Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b8/5427a0023116343a8d787b446536a7fddfa5db7eec7713dd05618da2bdfe/prek-0.4.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a427b792c4436f49732b1f6ebccf221fdcc6390c148474280da9c2c6eaabc9c4", size = 5910136, upload-time = "2026-06-04T07:26:20.616Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/4f/d751e90b7e768e472e054cd41cbe502589436ca9c1a13bfe4fa9513f9cde/prek-0.4.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b998038fc92c990e03147eb5b95b0f2c394517f8857ab911aac8e092f1b9b3ab", size = 5470124, upload-time = "2026-06-04T07:26:29.23Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/fe/e73241c5777b6f9b6b95132febbd27f9be9e89912e9e93c0982680593af2/prek-0.4.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:9cebca8c15da4f1d6e3a25e6ae0611425c8596e926222050f2588c390e42df8a", size = 5732725, upload-time = "2026-06-04T07:26:19.133Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a3/329bd910e7e5d9d0eb5e571f3ba48023213744e78411afb81f5ef8356cab/prek-0.4.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c8742ac26363e74c855df6215a709d5db183204d00ac0f1a722b13aed4da3cd0", size = 5457953, upload-time = "2026-06-04T07:26:23.41Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f8/d642990513d9707398506bad45d39173d84266231f7d919899f694aefe2c/prek-0.4.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a2b7c8710546a1e894afa7ab022030cd4e21f1ee7ffb301b4360773d22f1f00f", size = 5860556, upload-time = "2026-06-04T07:26:11.692Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/17/a2e29cb278503a8c18612d8a62a15020648dc768e2e94bc4b4d4c9411e07/prek-0.4.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e02bd4d5e05c500e4d9f70f024e30d13aa361dc490724b7f476d2e35542c239f", size = 6652492, upload-time = "2026-06-04T07:26:09.962Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/10/ad3270b18135ee5d1af6f6cf4b0c8601b1cc2cb38d16e835081da820833a/prek-0.4.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f3a25041733de987a47e5a7bace47182a6f0e2ae5f960cb54c1d4630afd2591", size = 6113837, upload-time = "2026-06-04T07:26:24.873Z" },
+    { url = "https://files.pythonhosted.org/packages/59/d9/e8c201b9b41c4561673cea01c630ab604df89d13e952f87dbcb807d32588/prek-0.4.4-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:0b04a0f36d07474f2a9fc5b1ba1197a1b326b2b211f39cd74cf0d4613545f7f4", size = 5729155, upload-time = "2026-06-04T07:26:26.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cd/227b0494fcbc91e8fe15c2a4db9e6dfff95314ef38db3e40e6ea96db249d/prek-0.4.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:f032ccbe2d6edc345f81a6d772c18cc169d63c27b5a8292bfe416b352bdfee57", size = 5590775, upload-time = "2026-06-04T07:26:22.038Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/e0/9d750b9cf21ece884afdc15668d0f005a36588fe1b0bb5ff4a8112ab51cb/prek-0.4.4-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:bad3586fcea3e913f0edf2e8f132f97889e03976b7ee3d120fd294ad4e89a5eb", size = 5437864, upload-time = "2026-06-04T07:26:30.673Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/48/e2e5c0299590ad18a253c0ac09508b615baa1b382010c511186572f711d3/prek-0.4.4-py3-none-musllinux_1_1_i686.whl", hash = "sha256:4058638532c6dcbf0076d23b9264cbdd9f0f0e320762e237a6b9e4e4b854a766", size = 5718579, upload-time = "2026-06-04T07:26:27.786Z" },
+    { url = "https://files.pythonhosted.org/packages/54/48/7fb3d4e7f664d1ce8ae35ec553872ffddf9fab4c5081735fdaae610b1e7c/prek-0.4.4-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:619bab14071670249777deea0cc0b29d904c4a514cf33b20e583900a544f0399", size = 6231622, upload-time = "2026-06-04T07:26:16.309Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c0/a4ddbf38034afe67cfa97c4bd81c86429ada098e7c323218d9f9fd061566/prek-0.4.4-py3-none-win32.whl", hash = "sha256:143154b329c05b2f9fa3230e604d02d9c4297dd43f96135a8ba166772e8ecd60", size = 5240317, upload-time = "2026-06-04T07:26:08.726Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/8c/fe97b5b095187bb2f93bbe406bccf108c879e5e4c83f165809b0d16ce0fb/prek-0.4.4-py3-none-win_amd64.whl", hash = "sha256:c38c5140ae2ea55ebb02e6ca590a416664ea1af287cdd21f54daeec53a81015a", size = 5626104, upload-time = "2026-06-04T07:26:14.81Z" },
+    { url = "https://files.pythonhosted.org/packages/25/63/3586226d536796e65f8e725b531d6104e55caaa18659bdcb512661629586/prek-0.4.4-py3-none-win_arm64.whl", hash = "sha256:3efa28fb37b9ddbafb7759da8d497f0d36cf02a05816e15d6541f5669d5d2114", size = 5470399, upload-time = "2026-06-04T07:26:13.231Z" },
 ]
 
 [[package]]

--- a/plugins/cc-plugin-codex/uv.lock
+++ b/plugins/cc-plugin-codex/uv.lock
@@ -148,7 +148,7 @@ wheels = [
 
 [[package]]
 name = "cc-plugin-codex"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary
- constrain explicit workspace roots to negotiated MCP roots when roots are available
- split destructive job result consumption into claude_job_consume_result and fix lifecycle annotations
- add distinct API key errors, async polling/TTL metadata, deprecation policy, and updated docs/tests

## Verification
- uv run pytest
- uv run ruff check .