### PR TITLE
Harden cc-plugin-codex agent contract

### DIFF
--- a/docs/cc-plugin-codex-action-plan.md
+++ b/docs/cc-plugin-codex-action-plan.md
@@ -1,0 +1,99 @@
+# cc-plugin-codex Improvement Action Plan
+
+> **Status: implemented (2026-06-04).** All 8 items shipped, reviewed by Codex, with the
+> `FINGERPRINT` bumped `schema-8` → `schema-9` and the plugin version `0.1.1` → `0.1.2`.
+> Item 1 uses the warn-in-meta approach. 135 tests pass (12 new); `ruff check` clean.
+
+
+Derived from [the evaluation scenarios](./cc-plugin-codex-evaluation-scenarios.md), cross-checked against the source, and reviewed independently by Codex.
+Two issues were found that the evaluation missed (items 6 and 7 below).
+
+All paths are under `plugins/cc-plugin-codex/`.
+
+## Fingerprint policy
+
+Several items change the agent-visible surface (new tools, new `meta` fields, error wording, capability guarantees), which by the policy in `schemas.py` requires bumping `FINGERPRINT`.
+**Batch every accepted change into a single bump** (`schema-8` → `schema-9`) rather than incrementing per change.
+
+## Tier 1 — Correctness / safety (do first)
+
+### 1. Workspace silently defaults to the plugin install directory
+- **Problem (confirmed).** `_resolve_workspace` (`server.py:163-185`) falls back to `os.getcwd()` when there is no `workspace_root` arg and no MCP root. Because the server process launches from its own install dir, paid reviews silently run against the wrong repo. The evaluation reproduced this (`meta.cwd` = `plugins/cc-plugin-codex`).
+- **Decision point (recommended default below).**
+  - *Recommended — warn, don't break:* when `workspace_source == "cwd"`, add a non-fatal `meta.workspace_warning` ("resolved from the server's own cwd; pass workspace_root to be sure"). Combined with item 2's dry-run and item 8's skill change, this fixes the footgun without breaking existing callers.
+  - *Stricter — Codex's preference:* refuse paid calls with no `workspace_root` and no MCP root unless an opt-in env (`CC_PLUGIN_CODEX_ALLOW_CWD=1`) is set. Safer, but breaking.
+- **Files:** `server.py` (`_resolve_workspace`, `_meta`), `schemas.py` (`Meta`).
+- **Compat:** warn = additive; strict = breaking. Bumps fingerprint.
+
+### 2. No free dry-run before paying
+- **Problem (confirmed).** `gather_context` (`context.py:100-114`) already computes diff summary, byte size, truncation, and redacted paths — but nothing exposes it without a paid call. Agents can't see what they're about to send or where.
+- **Fix.** Add a free, read-only `claude_review_dry_run(scope, base, focus?, workspace_root?)` returning: resolved `cwd` + `workspace_source`, `ContextSummary`, diff byte count, `truncated`/hint, and `redacted_paths` count + list. Pure reuse of existing code; no Claude call. This also subsumes the evaluation's "surface workspace in status" idea (item 9) more cleanly than touching `claude_status`.
+- **Files:** `server.py` (new tool), `context.py` (expose `redacted_paths`/byte count it already gathers), `schemas.py` (new result model).
+- **Compat:** additive. Bumps fingerprint.
+
+### 3. `claude_status` leaks account email + org
+- **Problem (confirmed).** `auth_status` (`claude.py:47-59`) returns `claude auth status --text` verbatim as `auth_detail`; `claude_status` passes it straight through (`server.py:652`). Sensitive in shared logs/transcripts.
+- **Fix.** Keep the boolean `claude_authenticated`; redact `auth_detail` to a non-identifying summary by default (strip email/org), or drop it. Optionally gate the raw string behind `detail="full"`.
+- **Files:** `claude.py` (`auth_status`), `server.py` (`claude_status`), `schemas.py` (`StatusResult`).
+- **Compat:** changing/removing `auth_detail` is breaking. Bumps fingerprint.
+
+## Tier 2 — Accuracy of the budget contract
+
+### 4. Budget cap is not a hard cap, and `meta` doesn't echo what was requested
+- **Problem (confirmed).** `--max-budget-usd` is a Claude-CLI stop threshold, not a hard ceiling — the evaluation saw `$0.01` cap → `$0.048` actual. Worse, the code itself overstates it: `jobs.py:12` ("`--max-budget-usd` still hard-bounds spend"), `server.py:438-439` ("budget cap"), `claude.py:142-145` ("max-budget cap"). `Meta` (`schemas.py:72-90`) reports `cost_usd` but never the requested budget, so an agent can't compare requested vs actual without retaining call args.
+- **Fix.**
+  - Add `meta.requested_max_budget_usd` (set in `_execute`/job start).
+  - Replace "hard-bounds"/"cap" wording with "stop threshold (best-effort, may be exceeded)" in `jobs.py`, `server.py`, `claude.py`, README, and SKILL.
+- **Files:** `schemas.py`, `server.py`, `jobs.py`, `claude.py`, `README.md`, `SKILL.md`.
+- **Compat:** `meta` field is additive; wording is docs. Bumps fingerprint (meta schema change).
+
+## Tier 3 — Ergonomics & discovery
+
+### 5. No `claude_job_list`
+- **Problem (confirmed).** Jobs persist on disk keyed by workspace (`jobs.py:70-79`), but every lifecycle tool needs a known `job_id`. Ids are lost across context compaction with no way to recover them.
+- **Fix.** Add free `claude_job_list(workspace_root?)` returning recent jobs (id, kind, status, started_at, expires_at, cost when terminal). Thin wrapper over `_ws_dir` + `_read_meta` + `_status_of`.
+- **Files:** `jobs.py` (new `list_jobs`), `server.py` (new tool), `schemas.py` (new model).
+- **Compat:** additive. Bumps fingerprint.
+
+### 6. SKILL.md omits the `access=readonly` redaction caveat *(missed by evaluation)*
+- **Problem (confirmed).** README.md:93-96 correctly warns that with `access=readonly` Claude can `Read`/`Grep`/`Glob` any workspace file, so filename-based redaction does **not** protect it. SKILL.md:38-40 — the agent-facing surface — omits this and reads as if redaction always protects secrets. This is a safety gap, not just a doc gap.
+- **Fix.** Copy the README caveat into `SKILL.md` (and consider surfacing it in `cc_codex_capabilities` negative-scope/prerequisites).
+- **Files:** `SKILL.md`, optionally `server.py` (`cc_codex_capabilities`).
+- **Compat:** docs; fingerprint only if capability guarantees change.
+
+### 7. Discovery: capability tool is hard to guess / not in deferred tool search
+- **Problem (partly confirmed).** The evaluation found Codex's deferred `tool_search` didn't surface these tools and `cc_codex_capabilities` is an unlikely guess. The tool-search indexing behavior is inferred (not visible in our code); the naming point is valid regardless.
+- **Fix.** Add a `claude_capabilities` alias for `cc_codex_capabilities`; enrich tool titles/descriptions with discovery keywords (review, second opinion, critique, adversarial).
+- **Files:** `server.py`.
+- **Compat:** additive. Bumps fingerprint.
+
+### 8. Documentation gaps in the skill
+- **Problem (confirmed).** SKILL.md lacks: a realistic minimum budget (the evaluation saw `$0.01` too low; ~`$0.02` for a one-sentence ask, more for reviews), the "budget is a stop threshold, not a hard cap" note (item 4), and prominent "pass `workspace_root` on the first call" guidance (item 1).
+- **Fix.** Add a short budget-expectations note, the stop-threshold clarification, and move `workspace_root` guidance to the top of the skill.
+- **Files:** `SKILL.md`, `README.md`.
+- **Compat:** docs only.
+
+## Items deliberately NOT pursued
+
+- **Workspace info inside `claude_status`** (evaluation Scenario 2/6): `claude_status` has no `ctx`, so it can't resolve roots. The dry-run tool (item 2) covers this better — skip.
+- **Preflight cost estimate / "ping Claude" path** (Scenario 4): the CLI offers no cheap no-work probe; the dry-run (size/redaction) is the practical substitute. Skip the cost estimate.
+
+## Reconciled with Codex review (locked decisions)
+
+- **Item 1:** warn-in-meta chosen (not hard-require). Set `meta.workspace_warning` centrally in `_meta(...)` when `workspace_source == "cwd"`; name the resolved `cwd` and tell the caller to pass `workspace_root`. Preserve it through `jobs._build_meta`.
+- **Item 2:** `ContextResult` already returns `redacted_paths`, but `server.py` drops it and there is no byte count anywhere — add `diff_bytes` to `ContextResult` and surface both. Dry-run uses a dedicated result model (no `verdict`, no diff text): `cwd`, `workspace_source`, `workspace_warning`, `scope`, `base`, `context_summary`, `diff_bytes`, `max_diff_bytes`, `truncated`, `truncation_hint`, `redacted_paths_count`, `redacted_paths`, `fingerprint`.
+- **Item 3:** replace `auth_detail` with a non-identifying phrase (authenticated / not authenticated / probe failed). No `detail="full"` backdoor — the boolean already carries the machine-readable truth.
+- **Item 4:** `meta.requested_max_budget_usd` = the **effective clamped** budget (`r.budget`), thread it everywhere `_meta` is built (incl. error/truncation metas) and persist it in `JobConfig` → `_build_meta`.
+- **Item 5:** `claude_job_list` is NOT read-only — `_reap_workspace`/`_status_of` write metadata and may kill timed-out jobs. Annotate it with the local-mutation hints like `claude_job_status`.
+- **Item 7:** implement `claude_capabilities` via a shared helper so it can't drift from `cc_codex_capabilities`. Frame as name/description discoverability only — deferred tool-search behavior is a client concern we can't guarantee.
+- **Also (README wording):** fix "caps cost" / "budget cap bounds spend" at README.md:99,120 alongside item 4.
+- **Tests that will break:** `schema-8` is hardcoded in `test_schemas.py` and `test_server.py`; `JobConfig` gains a field so `test_jobs.py::_cfg()` needs a default/update; `test_context.py` for the new byte/redaction surfacing; `test_claude.py` for budget wording. Bump `FINGERPRINT` to `schema-9` **last**, in one pass with the test updates.
+
+## Suggested execution order
+
+1. Items 4 + 8 (meta field + wording/doc fixes) — cheap, no risk, sets the budget story straight.
+2. Items 3 + 6 (redaction: status leak + skill caveat) — safety, small.
+3. Item 2 (dry-run tool) — highest ergonomic payoff, reuses existing code.
+4. Item 1 (workspace warning) — fold into item 2's work; decide warn vs. strict.
+5. Items 5 + 7 (job_list + capability alias) — additive niceties.
+6. Single `FINGERPRINT` bump to `schema-9` covering all surface changes; update tests in `tests/`.

--- a/docs/cc-plugin-codex-evaluation-scenarios.md
+++ b/docs/cc-plugin-codex-evaluation-scenarios.md
@@ -1,0 +1,197 @@
+# cc-plugin-codex Evaluation Scenarios
+
+Lightweight scenarios for checking whether the installed `cc-plugin-codex` tools are discoverable, predictable, and useful from Codex.
+
+## Scope
+
+These scenarios are intentionally small. They should be runnable in a normal Codex session without preparing a special fixture repository, and they avoid large paid Claude calls unless explicitly noted.
+
+Use `max_budget_usd`, `timeout_seconds`, and low reasoning effort for paid-path probes. Treat paid results as sampled behavior, not a full acceptance test.
+
+## Scenario 1: Discover The Tool Surface
+
+Goal: Confirm an agent can identify what the plugin does and which tool to call first.
+
+Steps:
+
+1. Search for a Claude review or second-opinion capability through the available tool discovery mechanism.
+2. Read the installed skill, if available: `cc-plugin-codex:collaborating-with-claude`.
+3. Call `cc_codex_capabilities`.
+
+Expected:
+
+- The skill or tool list should make it clear that this plugin is review-only.
+- `cc_codex_capabilities` should identify paid and free tools, access modes, config modes, prerequisites, and negative scope.
+- The first low-risk tool should be obvious: `claude_status`.
+
+Observed locally:
+
+- The skill clearly explained the tool choice: `claude_ask`, `claude_review_changes`, `claude_review_changes_async`, `claude_adversarial_review`, and `claude_status`.
+- `cc_codex_capabilities` returned a compact contract with fingerprint `cc-plugin-codex/0.1/schema-8`.
+- Deferred `tool_search` for "Claude Code review second opinion adversarial critique status async job" did not surface these MCP tools; it returned unrelated multi-agent tools. Discovery currently depends on the upfront MCP tool list or the skill list.
+
+Improvement candidates:
+
+- Add discovery keywords to any surface that feeds deferred tool search, if available.
+- Consider naming the capability contract tool `claude_capabilities` or adding an alias. `cc_codex_capabilities` is precise, but less likely to be guessed by an agent looking for Claude tools.
+
+## Scenario 2: Readiness Check Before Spending
+
+Goal: Verify an agent can check whether a paid call is likely to work before invoking Claude.
+
+Steps:
+
+1. Call `claude_status`.
+2. Inspect `ready`, `claude_found`, `claude_authenticated`, `version_supported`, available config modes, default budget, and default timeout.
+
+Expected:
+
+- No paid Claude call should be made.
+- The result should be a structured `ok:true` response.
+- If the CLI is unavailable or unauthenticated, the response should give a repair path.
+
+Observed locally:
+
+- `claude_status` was fast and returned `ready:true`.
+- It reported Claude Code `2.1.162`, authenticated OAuth details, supported version, config mode availability, budget bounds, timeout bounds, and a clear caveat that `config_mode=bare` needs `ANTHROPIC_API_KEY`.
+
+Improvement candidates:
+
+- The readiness result includes account email and organization. That is useful for debugging, but it is potentially sensitive in shared logs. Consider a `detail` option or redacted summary mode.
+- Surface the default workspace resolution in `claude_status`. In this install, paid calls without `workspace_root` reported `cwd` as `plugins/cc-plugin-codex`, which may surprise users working from the repository root.
+
+## Scenario 3: Minimal Free Error Path
+
+Goal: Confirm free job-management tools fail clearly.
+
+Steps:
+
+1. Call `claude_job_status` with a fake job id such as `not-a-real-job-id`.
+
+Expected:
+
+- The response should be `ok:false`.
+- The error should identify the bad parameter, explain whether retrying helps, and provide a repair hint.
+
+Observed locally:
+
+- The tool returned `ok:false`, `code:"job_not_found"`, `offending_param:"job_id"`, `retryable:false`, and a useful repair message.
+
+Improvement candidates:
+
+- This path behaved as expected.
+
+## Scenario 4: Small Second Opinion
+
+Goal: Verify the cheapest common paid path: a bounded free-form opinion.
+
+Steps:
+
+1. Call `claude_ask` with a one-sentence prompt.
+2. Use `effort:"low"`, `access:"toolless"`, `config_mode:"inherit"`, and a small budget.
+
+Expected:
+
+- The tool should return `ok:true` with `tool:"claude_ask"`, `summary`, `verdict`, `confidence`, `findings`, `questions`, `assumptions`, `next_steps`, and `meta`.
+- `meta` should include elapsed time, cost, usage, request id, and fingerprint.
+
+Observed locally:
+
+- With `max_budget_usd:0.01`, the tool returned `budget_exceeded`.
+- With `max_budget_usd:0.10`, the tool succeeded in about 8 seconds and returned the documented envelope.
+- The successful call cost about `$0.018`.
+
+Improvement candidates:
+
+- Document a realistic minimum budget for even tiny calls. `$0.01` was too low for a one-sentence prompt in this environment.
+- Consider exposing a preflight estimate or a cheaper "ping Claude with no model work" path if the Claude CLI supports it.
+
+## Scenario 5: Budget Guard Behavior
+
+Goal: Verify budget failures are understandable and bounded.
+
+Steps:
+
+1. Call `claude_ask` or `claude_review_changes` with an intentionally tiny `max_budget_usd`.
+2. Inspect the error envelope and `meta.cost_usd`.
+
+Expected:
+
+- The tool should fail with `ok:false`, `code:"budget_exceeded"`, and `retryable:true`.
+- The repair should suggest raising budget or reducing context.
+- Actual spend should be close to or below the requested cap, subject to Claude CLI behavior.
+
+Observed locally:
+
+- Both `claude_ask` and `claude_review_changes` produced clear `budget_exceeded` envelopes.
+- Reported cost exceeded the requested cap in both probes:
+  - Ask: cap `$0.01`, reported cost about `$0.048`.
+  - Working-tree review: cap `$0.05`, reported cost about `$0.077`.
+
+Improvement candidates:
+
+- Document that `max_budget_usd` is enforced by the Claude CLI and may not be a hard upper bound in reported accounting.
+- If feasible, add server-side budget wording such as "stop threshold" rather than "cap", or apply a conservative lower value when invoking Claude.
+- Include the requested budget in `meta` so an agent can compare requested versus actual without retaining call arguments.
+
+## Scenario 6: Working-Tree Review
+
+Goal: Verify a normal code-review call targets the intended repository and handles context size.
+
+Steps:
+
+1. Create or use a small tracked working-tree diff.
+2. Call `claude_review_changes` with `scope:"working_tree"`.
+3. Pass `workspace_root` explicitly.
+
+Expected:
+
+- The tool should review the diff and return structured findings.
+- `meta.workspace_source` should be `param`.
+- Findings should include concrete file and line references when possible.
+
+Observed locally:
+
+- Passing `workspace_root:"/Users/bdc/projects/briandconnelly-plugins"` correctly changed `meta.cwd` to the repository root and `workspace_source` to `param`.
+- A low-budget review hit `budget_exceeded`, but the failure path was structured and useful.
+- Calling paid tools without explicit `workspace_root` used the plugin directory as cwd in this install.
+
+Improvement candidates:
+
+- Make the "pass explicit workspace_root" guidance more prominent in the skill, not only the README.
+- Consider adding a warning in paid-call metadata when the resolved workspace appears to be the plugin install directory.
+- Add a cheap dry-run tool for diff size and workspace resolution, so agents can inspect what would be sent before paying.
+
+## Scenario 7: Async Review Lifecycle
+
+Goal: Verify the background job lifecycle is understandable for large diffs.
+
+Steps:
+
+1. Start `claude_review_changes_async` against a small diff.
+2. Confirm the response includes `job_id`, `status`, `poll_after_ms`, and TTL metadata.
+3. Poll `claude_job_status`.
+4. Fetch with `claude_job_result` once `result_available:true`.
+5. Optionally call `claude_job_consume_result` to delete the result, or `claude_job_cancel` while running.
+
+Expected:
+
+- Starting the job should return quickly.
+- Status polling should not require knowing Claude internals.
+- Result shape should match synchronous `claude_review_changes`.
+
+Observed locally:
+
+- Not run in this pass to avoid another paid review.
+- The free fake-job status path behaved correctly.
+
+Improvement candidates:
+
+- Provide a documented "cancel immediately" smoke test for async jobs with a tiny fixture diff and low budget.
+- Consider a free `claude_job_list` tool scoped to the workspace. Agents often lose job ids across context compaction or user interruption.
+
+## Overall Assessment
+
+The installed tools are usable and mostly behave as documented. The strongest parts are the compact capability contract, the free readiness check, the clear `ok`-discriminated result envelopes, and the explicit separation between free status/job tools and paid Claude calls.
+
+The main rough edges are discoverability outside the skill/upfront tool list, surprising default workspace resolution in this install, budget-cap expectations, and the lack of a free dry-run that shows workspace, diff size, redaction count, and estimated context before invoking Claude.

--- a/plugins/cc-plugin-codex/.codex-plugin/plugin.json
+++ b/plugins/cc-plugin-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-plugin-codex",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Call Claude Code from Codex for bounded, independent code review and second opinions",
   "author": { "name": "Brian Connelly", "url": "https://github.com/briandconnelly" },
   "repository": "https://github.com/briandconnelly/cc-plugin-codex",

--- a/plugins/cc-plugin-codex/README.md
+++ b/plugins/cc-plugin-codex/README.md
@@ -11,8 +11,10 @@ tasks. Reviews can run synchronously or as background jobs, but Claude only ever
 An MCP server wraps the `claude` CLI and exposes read-only tools to Codex:
 `claude_ask`, `claude_review_changes`, `claude_adversarial_review`, and `claude_status`,
 plus `claude_review_changes_async` with `claude_job_status`/`claude_job_result`/
-`claude_job_consume_result`/`claude_job_cancel` for background reviews. Claude reviews;
-it never edits your code.
+`claude_job_consume_result`/`claude_job_cancel`/`claude_job_list` for background reviews.
+`claude_review_dry_run` previews workspace/diff-size/redaction for free before a paid
+review, and `cc_codex_capabilities` (alias `claude_capabilities`) returns the capability
+contract. Claude reviews; it never edits your code.
 
 Each tool publishes an output schema describing the `ok`-discriminated result
 (`{"ok": true, ...}` on success, `{"ok": false, "error": {code, message, repair}, ...}`
@@ -96,7 +98,10 @@ plugin install) so reviews target your project rather than the plugin checkout.
   when the workspace may contain secrets.
 - All `config_mode`s drop your other MCP servers, but `inherit`/`scoped` still load your
   user-level Claude hooks and settings; use `config_mode=bare` for full isolation.
-- Each call is paid and sends code to Anthropic; the server caps cost and time per call.
+- Each call is paid and sends code to Anthropic. `max_budget_usd` is a best-effort stop
+  threshold (enforced by the Claude CLI), not a hard cap — reported `meta.cost_usd` can
+  exceed it; `meta.requested_max_budget_usd` echoes the value sent. `timeout_seconds`
+  bounds wall-clock time per call.
 
 ## Background reviews
 
@@ -110,15 +115,15 @@ is read-only and leaves the stored record available until TTL cleanup. Use
 `claude_job_cancel` terminates a running job. The status/result/consume/cancel tools
 are free.
 
-The diff is gathered at launch (same secret redaction and `--max-budget-usd` cap as the
-sync path). Because the server drives one-shot `claude -p --output-format json`, a job's
+The diff is gathered at launch (same secret redaction and `--max-budget-usd` stop
+threshold as the sync path). Because the server drives one-shot `claude -p --output-format json`, a job's
 completion is simply "the process exited and wrote its JSON envelope" — no interactive
 log scraping. State lives on disk keyed by workspace, so status/result/cancel survive an
 MCP server restart. There is no daemon: overrunning jobs are stopped on the next status
 poll (deadline `CC_PLUGIN_CODEX_JOB_MAX_SECONDS`, default 1800s). Job start/status
 responses include `poll_after_ms`, `ttl_seconds`, and `expires_at` where known.
 Records are cleaned up after `CC_PLUGIN_CODEX_JOB_TTL` (default 24h), and the budget
-cap bounds spend even for a job nobody polls. Job records (which contain the diff)
+stop threshold still applies (best-effort) even for a job nobody polls. Job records (which contain the diff)
 are stored under
 `CC_PLUGIN_CODEX_STATE_DIR` (default `~/.cache/cc-plugin-codex/jobs`); anyone with access
 to that workspace's state directory can read or cancel its jobs.

--- a/plugins/cc-plugin-codex/prek.toml
+++ b/plugins/cc-plugin-codex/prek.toml
@@ -1,13 +1,10 @@
 # Configuration file for `prek`, a git hook framework written in Rust.
 #:schema https://www.schemastore.org/prek.json
-
-[[repos]]
-repo = "builtin"
-hooks = [
-  { id = "check-json", files = '^plugins/cc-plugin-codex/' },
-  { id = "end-of-file-fixer", files = '^plugins/cc-plugin-codex/' },
-  { id = "trailing-whitespace", files = '^plugins/cc-plugin-codex/' },
-]
+#
+# This is a nested (workspace-mode) config: prek runs these hooks with the working
+# directory set to this plugin folder, so commands use plain `uv run ...` (no
+# `--directory`). Repo-wide builtin checks (check-json, end-of-file-fixer,
+# trailing-whitespace) live in the root prek.toml and already cover this plugin.
 
 [[repos]]
 repo = "local"
@@ -16,7 +13,7 @@ repo = "local"
 id = "ruff-check"
 name = "ruff check"
 entry = "uv"
-args = ["--directory", "plugins/cc-plugin-codex", "run", "ruff", "check", "."]
+args = ["run", "ruff", "check", "."]
 language = "system"
 pass_filenames = false
 always_run = true
@@ -25,7 +22,7 @@ always_run = true
 id = "pytest"
 name = "pytest"
 entry = "uv"
-args = ["--directory", "plugins/cc-plugin-codex", "run", "pytest"]
+args = ["run", "pytest"]
 language = "system"
 pass_filenames = false
 always_run = true

--- a/plugins/cc-plugin-codex/pyproject.toml
+++ b/plugins/cc-plugin-codex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cc-plugin-codex"
-version = "0.1.1"
+version = "0.1.2"
 description = "Call Claude Code from Codex for bounded, independent code review and second opinions"
 requires-python = ">=3.10"
 dependencies = [

--- a/plugins/cc-plugin-codex/skills/collaborating-with-claude/SKILL.md
+++ b/plugins/cc-plugin-codex/skills/collaborating-with-claude/SKILL.md
@@ -8,6 +8,11 @@ description: Use when you want an independent second opinion, a code review, or 
 Use the `cc-plugin-codex` MCP tools to get bounded, independent critique from Claude Code.
 Claude is a reviewer, not a co-pilot: it never edits your code.
 
+**Pass `workspace_root` (an absolute repo path) on every paid call.**
+If you omit it and the client exposes no MCP root, the server falls back to its own
+install directory and silently reviews the wrong repository.
+The result `meta.workspace_warning` flags when this fallback happened.
+
 ## When to ask Claude
 
 Ask at genuine decision points, not reflexively:
@@ -25,6 +30,9 @@ Do NOT call Claude in a loop, and never call Claude just because Claude suggeste
 - `claude_review_changes_async` — same review as a background job for large diffs or when you want to keep working; returns a `job_id`. Poll `claude_job_status`, then `claude_job_result` (same envelope as the sync tool). Use `claude_job_consume_result` only when you want to fetch and delete the stored record; use `claude_job_cancel` to stop it.
 - `claude_adversarial_review` — Claude attacks a plan/claim and lists the strongest counterarguments.
 - `claude_status` — free readiness check: reports whether `claude` is installed, authenticated (`claude_authenticated`), version-compatible (`version_supported`), and overall `ready`, plus the resolved defaults a no-arg call would use. Run it first if a call fails, or to confirm readiness before spending.
+- `claude_review_dry_run` — free preview of what a diff review would send: resolved workspace, diff byte size, whether it would be truncated, and how many secret-looking files would be redacted. No paid call. Run it before a large review to confirm scope and workspace.
+- `claude_job_list` — free list of this workspace's background jobs (id, status, cost), newest first. Use it to recover a `job_id` lost across context compaction or interruption.
+- `cc_codex_capabilities` (alias `claude_capabilities`) — free capability contract: tool inventory, scope, prerequisites, and the fingerprint to pin.
 
 ## Reading results
 
@@ -35,8 +43,10 @@ Do NOT call Claude in a loop, and never call Claude just because Claude suggeste
 
 ## Guardrails
 
-- Each call is PAID and sends your code/diff to Anthropic. Call deliberately.
-- The server never sends `.env`/secret files; redaction is filename-based, not content-scanning, so do not paste secrets into prompts and do not rely on it to catch secrets hardcoded inside ordinary source files.
+- Each call is PAID and sends your code/diff to Anthropic. Call deliberately. Even a one-sentence `claude_ask` costs roughly `$0.02`; a real review costs more, so budgets below ~`$0.05` will usually trip `budget_exceeded`.
+- `max_budget_usd` is a best-effort stop threshold enforced by the Claude CLI, NOT a hard cap — reported `meta.cost_usd` can exceed it. `meta.requested_max_budget_usd` echoes the value sent so you can compare requested vs actual.
+- The server never sends `.env`/secret files in the diff it gathers; redaction is filename-based, not content-scanning, so do not paste secrets into prompts and do not rely on it to catch secrets hardcoded inside ordinary source files.
+- Diff redaction only covers the context the server gathers. With `access=readonly`, Claude can `Read`/`Grep`/`Glob` any file in the workspace directly, so redaction does NOT protect against secrets it reads itself — use `access=toolless` (the default) when the workspace may contain secrets.
 - Default access is `toolless` (Claude gets no tools) and `config_mode=inherit`; both access modes are read-only (Claude never gets write/Bash). Use `config_mode=bare` only when you want a fully independent reviewer and have `ANTHROPIC_API_KEY` set.
 - When client MCP roots are available, explicit `workspace_root` values must be inside one of those roots; omit `workspace_root` to use the first root.
 - Cap cost/time with `max_budget_usd` and `timeout_seconds` for large reviews.

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/claude.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/claude.py
@@ -49,14 +49,19 @@ def auth_status(timeout_seconds: int = 10) -> tuple[bool | None, str | None]:
 
     Returns (logged_in, detail). logged_in is None when the probe could not run
     (claude missing, timeout) so callers can report 'unknown' rather than a
-    misleading False."""
+    misleading False. detail is a NON-identifying phrase, never the raw CLI output:
+    `claude auth status` prints the account email and organization, which would leak
+    into shared logs/transcripts. The boolean already carries the machine-readable
+    truth, so we deliberately drop the raw text."""
     try:
         proc = subprocess.run(["claude", "auth", "status", "--text"],
                               capture_output=True, text=True, timeout=timeout_seconds)
     except (OSError, subprocess.SubprocessError):
         return None, None
-    detail = (proc.stdout or proc.stderr).strip() or None
-    return proc.returncode == 0, detail
+    logged_in = proc.returncode == 0
+    detail = ("Claude CLI reports an authenticated session." if logged_in
+              else "Claude CLI reports no authenticated session; run `claude /login`.")
+    return logged_in, detail
 
 
 def _kill_process_tree(proc: subprocess.Popen) -> None:
@@ -141,7 +146,8 @@ def classify_failure(run: ClaudeRun) -> ErrorInfo:
                          repair="Run `claude /login`.")
     if "budget" in blob:
         return ErrorInfo(code="budget_exceeded",
-                         message="claude hit the max-budget cap.",
+                         message="claude reached the max-budget stop threshold "
+                                 "(a best-effort limit, not a hard cap).",
                          repair="Raise max_budget_usd or reduce context.",
                          retryable=True)
     return ErrorInfo(code="nonzero_exit",

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/context.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/context.py
@@ -39,6 +39,7 @@ class ContextResult:
     truncated: bool = False
     truncation_hint: str | None = None
     redacted_paths: list[str] = field(default_factory=list)
+    diff_bytes: int = 0   # full (pre-truncation) UTF-8 byte size of the redacted diff
 
 
 def _git(cwd: str, *args: str) -> str:
@@ -105,10 +106,12 @@ def gather_context(cwd: str, scope: str, base: str) -> ContextResult:
     truncated = False
     hint = None
     encoded = text.encode("utf-8", "replace")
-    if len(encoded) > MAX_DIFF_BYTES:
+    diff_bytes = len(encoded)   # the true size, reported even when we truncate below
+    if diff_bytes > MAX_DIFF_BYTES:
         text = encoded[:MAX_DIFF_BYTES].decode("utf-8", "ignore")
         truncated = True
         hint = (f"diff exceeded {MAX_DIFF_BYTES} bytes; use scope=staged, choose "
                 "a closer branch base, or call claude_ask with selected context")
     return ContextResult(text=text, summary=summary, truncated=truncated,
-                         truncation_hint=hint, redacted_paths=redacted)
+                         truncation_hint=hint, redacted_paths=redacted,
+                         diff_bytes=diff_bytes)

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/jobs.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/jobs.py
@@ -9,7 +9,8 @@ a harness that tails an interactive CLI.
 State lives on disk (keyed by workspace), so status/result/cancel keep working
 across MCP server restarts. There is no daemon: reaping (deadline-kill of
 overrunning jobs, TTL cleanup, count cap) happens lazily on each lifecycle call,
-and ``--max-budget-usd`` still hard-bounds spend even for a job nobody polls.
+and ``--max-budget-usd`` still applies its best-effort spend stop threshold (not a
+hard cap) even for a job nobody polls.
 """
 
 from __future__ import annotations
@@ -27,7 +28,9 @@ from typing import Optional
 from uuid import uuid4
 
 from cc_plugin_codex.normalize import apply_cost_usage, normalize_envelope
-from cc_plugin_codex.schemas import FINGERPRINT, ContextSummary, Meta
+from cc_plugin_codex.schemas import (
+    FINGERPRINT, ContextSummary, Meta, workspace_warning_for,
+)
 
 STATE_ENV = "CC_PLUGIN_CODEX_STATE_DIR"
 TTL_ENV = "CC_PLUGIN_CODEX_JOB_TTL"
@@ -171,6 +174,7 @@ class JobConfig:
     timeout_seconds: int
     workspace_source: Optional[str]
     context_summary: Optional[ContextSummary]
+    requested_max_budget_usd: Optional[float] = None
 
 
 def start_job(cmd: list[str], cwd: str, cfg: JobConfig) -> tuple[str, str]:
@@ -204,6 +208,7 @@ def start_job(cmd: list[str], cwd: str, cfg: JobConfig) -> tuple[str, str]:
             "scope": cfg.scope, "base": cfg.base, "detail": cfg.detail,
             "timeout_seconds": cfg.timeout_seconds,
             "workspace_source": cfg.workspace_source, "cwd": cwd,
+            "requested_max_budget_usd": cfg.requested_max_budget_usd,
         },
         "context_summary": summary,
     }
@@ -303,13 +308,17 @@ def _rmtree(jd: Path) -> None:
 
 def _build_meta(meta: dict, status: str) -> Meta:
     c = meta.get("config", {})
+    cwd = c.get("cwd", "")
+    source = c.get("workspace_source")
     return Meta(
-        cwd=c.get("cwd", ""),
-        workspace_source=c.get("workspace_source"),
+        cwd=cwd,
+        workspace_source=source,
+        workspace_warning=workspace_warning_for(source, cwd),
         config_mode=c.get("config_mode", "inherit"),
         access=c.get("access", "toolless"),
         scope=c.get("scope"), base=c.get("base"),
         timeout_seconds=c.get("timeout_seconds", max_seconds()),
+        requested_max_budget_usd=c.get("requested_max_budget_usd"),
         elapsed_ms=_elapsed_ms(meta),
         job_id=meta.get("job_id"),
     )
@@ -343,6 +352,44 @@ def status(cwd: str, job_id: str) -> Optional[dict]:
         "cost_usd": cost, "detail": detail,
         "fingerprint": FINGERPRINT,
     }
+
+
+def list_jobs(cwd: str) -> dict:
+    """Return a JobListResult dict of the workspace's known jobs, newest first.
+
+    Reaps first (like the other lifecycle calls), so listing can refresh statuses
+    and delete expired records — it is not strictly read-only."""
+    _reap_workspace(cwd)
+    ws = _ws_dir(cwd)
+    summaries = []
+    if ws.is_dir():
+        for jd in ws.iterdir():
+            if not jd.is_dir():
+                continue
+            meta = _read_meta(jd)
+            if meta is None:
+                continue
+            state = _status_of(jd, meta)
+            cost = None
+            if state == "done":
+                env = _read_envelope(jd) or {}
+                c = env.get("total_cost_usd")
+                cost = float(c) if isinstance(c, (int, float)) else None
+            summaries.append({
+                "_epoch": meta.get("started_epoch", 0.0),
+                "job_id": meta.get("job_id", jd.name),
+                "kind": meta.get("kind", ""),
+                "status": state,
+                "started_at": meta.get("started_at", ""),
+                "elapsed_ms": _elapsed_ms(meta),
+                "result_available": state == "done",
+                "expires_at": _expires_at(meta),
+                "cost_usd": cost,
+            })
+    summaries.sort(key=lambda s: s["_epoch"], reverse=True)  # newest first
+    for s in summaries:
+        s.pop("_epoch", None)
+    return {"ok": True, "jobs": summaries, "fingerprint": FINGERPRINT}
 
 
 def _stderr_tail(jd: Path, limit: int = 200) -> Optional[str]:

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/jobs.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/jobs.py
@@ -324,6 +324,20 @@ def _build_meta(meta: dict, status: str) -> Meta:
     )
 
 
+def _terminal_cost(jd: Path, state: str) -> Optional[float]:
+    """Spend recorded by a terminal job, or None.
+
+    A cancelled/timeout job can still leave a parseable (possibly partial) envelope
+    that recorded cost, so we surface cost for ANY terminal state — matching the
+    result path (_job_error) and the JobStatus.cost_usd contract ('terminal jobs
+    that spent'), not just done."""
+    if state not in _TERMINAL:
+        return None
+    env = _read_envelope(jd) or {}
+    c = env.get("total_cost_usd")
+    return float(c) if isinstance(c, (int, float)) else None
+
+
 def status(cwd: str, job_id: str) -> Optional[dict]:
     """Return a JobStatus dict, or None if the job does not exist."""
     _reap_workspace(cwd)
@@ -332,11 +346,7 @@ def status(cwd: str, job_id: str) -> Optional[dict]:
     if meta is None:
         return None
     state = _status_of(jd, meta)
-    cost = None
-    if state == "done":
-        env = _read_envelope(jd) or {}
-        c = env.get("total_cost_usd")
-        cost = float(c) if isinstance(c, (int, float)) else None
+    cost = _terminal_cost(jd, state)
     detail = None
     if state == "failed":
         detail = _stderr_tail(jd)
@@ -370,11 +380,6 @@ def list_jobs(cwd: str) -> dict:
             if meta is None:
                 continue
             state = _status_of(jd, meta)
-            cost = None
-            if state == "done":
-                env = _read_envelope(jd) or {}
-                c = env.get("total_cost_usd")
-                cost = float(c) if isinstance(c, (int, float)) else None
             summaries.append({
                 "_epoch": meta.get("started_epoch", 0.0),
                 "job_id": meta.get("job_id", jd.name),
@@ -384,7 +389,7 @@ def list_jobs(cwd: str) -> dict:
                 "elapsed_ms": _elapsed_ms(meta),
                 "result_available": state == "done",
                 "expires_at": _expires_at(meta),
-                "cost_usd": cost,
+                "cost_usd": _terminal_cost(jd, state),
             })
     summaries.sort(key=lambda s: s["_epoch"], reverse=True)  # newest first
     for s in summaries:

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/schemas.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/schemas.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 # Bump this whenever the agent-visible surface changes: tool names, input or
 # output schemas, the ErrorCode set, the config_mode/access/scope/detail value
 # sets, or the capability guarantees in CAPABILITY_SUMMARY. Clients cache by it.
-FINGERPRINT = "cc-plugin-codex/0.1/schema-8"
+FINGERPRINT = "cc-plugin-codex/0.1/schema-9"
 
 Severity = Literal["critical", "high", "medium", "low", "nit"]
 Verdict = Literal["pass", "concerns", "fail", "unknown"]
@@ -23,6 +23,21 @@ Effort = Literal["low", "medium", "high", "xhigh", "max"]
 # Lifecycle states for a background job. Terminal: done|failed|cancelled|timeout.
 # (TTL-expired records are deleted and reported as job_not_found, not a state.)
 JobState = Literal["running", "done", "failed", "cancelled", "timeout"]
+
+
+def workspace_warning_for(source: str | None, cwd: str) -> str | None:
+    """Warning when the workspace was resolved from the server's own cwd.
+
+    The MCP server process launches from its install directory, so a cwd-resolved
+    workspace silently reviews the wrong repo. Surfacing this (rather than failing)
+    lets agents notice and pass workspace_root without breaking existing callers.
+    Shared by the sync meta builder and the background-job meta rebuild so the two
+    paths cannot drift."""
+    if source == "cwd":
+        return (f"workspace resolved from the server's own cwd ({cwd}); pass "
+                "workspace_root (or configure an MCP root) to be sure the review "
+                "targets the intended repository")
+    return None
 
 ErrorCode = Literal[
     "claude_not_found", "claude_auth_required", "api_key_missing", "api_key_invalid",
@@ -73,12 +88,17 @@ class Meta(BaseModel):
     model_config = ConfigDict(extra="forbid")
     cwd: str
     workspace_source: Optional[str] = None   # how cwd was resolved: param|roots|cwd
+    workspace_warning: Optional[str] = None   # set when cwd was resolved from server cwd
     config_mode: ConfigMode
     access: Access
     scope: Optional[str] = None
     base: Optional[str] = None
     timeout_seconds: int
     elapsed_ms: int
+    # The effective (env-defaulted + clamped) value passed to claude as
+    # --max-budget-usd. It is a best-effort stop threshold, not a hard cap; compare
+    # against cost_usd to see how close actual spend came.
+    requested_max_budget_usd: Optional[float] = None
     truncated: bool = False
     truncation_hint: Optional[str] = None
     command_exit_code: Optional[int] = None
@@ -203,6 +223,46 @@ class JobStatus(BaseModel):
     fingerprint: str = FINGERPRINT
 
 
+class DryRunResult(BaseModel):
+    """Free preview of what a diff review WOULD send — no Claude call, no spend."""
+    model_config = ConfigDict(extra="forbid")
+    ok: Literal[True] = True
+    tool: Literal["claude_review_dry_run"] = "claude_review_dry_run"
+    cwd: str
+    workspace_source: Optional[str] = None
+    workspace_warning: Optional[str] = None
+    scope: str
+    base: Optional[str] = None
+    context_summary: ContextSummary
+    diff_bytes: int              # full UTF-8 size of the redacted diff that would be sent
+    max_diff_bytes: int          # the server's truncation threshold
+    truncated: bool = False      # true when diff_bytes > max_diff_bytes
+    truncation_hint: Optional[str] = None
+    redacted_paths_count: int = 0
+    redacted_paths: list[str] = Field(default_factory=list)
+    fingerprint: str = FINGERPRINT
+
+
+class JobSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    job_id: str
+    kind: str
+    status: JobState
+    started_at: str
+    elapsed_ms: int
+    result_available: bool = False
+    expires_at: Optional[str] = None
+    cost_usd: Optional[float] = None
+
+
+class JobListResult(BaseModel):
+    """Returned by claude_job_list: the workspace's known jobs, newest first."""
+    model_config = ConfigDict(extra="forbid")
+    ok: Literal[True] = True
+    jobs: list[JobSummary] = Field(default_factory=list)
+    fingerprint: str = FINGERPRINT
+
+
 def _object_union_schema(adapter: TypeAdapter) -> dict:
     """Wrap a model union's anyOf in a top-level object schema.
 
@@ -231,3 +291,6 @@ CAPABILITIES_SCHEMA = CapabilitiesResult.model_json_schema()
 # the start tools advertise the JobStarted|ErrorResult union.
 JOB_STARTED_SCHEMA = _object_union_schema(TypeAdapter(JobStarted | ErrorResult))
 JOB_STATUS_SCHEMA = _object_union_schema(TypeAdapter(JobStatus | ErrorResult))
+# Dry-run and job-list can fail (bad scope/base/workspace), so advertise the union.
+DRY_RUN_SCHEMA = _object_union_schema(TypeAdapter(DryRunResult | ErrorResult))
+JOB_LIST_SCHEMA = _object_union_schema(TypeAdapter(JobListResult | ErrorResult))

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
@@ -800,14 +800,6 @@ def _capabilities_payload() -> dict:
     return result.model_dump(mode="json", exclude_none=True)
 
 
-_CAPABILITIES_DOC = (
-    "Return the compact capability contract for this server: tool inventory (review, "
-    "second opinion, adversarial critique), scope/negative-scope, prerequisites, modes, "
-    "deprecation policy, and fingerprint.\n\n"
-    "Free and read-only. Call first when unsure which Claude review tool to use."
-)
-
-
 @mcp.tool(annotations=_FREE_READ_ANNOTATIONS, title="cc-plugin-codex capabilities",
           output_schema=CAPABILITIES_SCHEMA)
 def cc_codex_capabilities() -> ToolResult:

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
@@ -25,29 +25,31 @@ from cc_plugin_codex.config import (
     sanitize_effort, version_supported,
 )
 from cc_plugin_codex.context import (
-    InvalidBaseError, InvalidScopeError, gather_context,
+    MAX_DIFF_BYTES, InvalidBaseError, InvalidScopeError, gather_context,
 )
 from cc_plugin_codex import jobs
 from cc_plugin_codex.jobs import JobConfig
 from cc_plugin_codex.normalize import apply_cost_usage, build_prompt, normalize_envelope
 from cc_plugin_codex.schemas import (
-    CAPABILITIES_SCHEMA, FINGERPRINT, JOB_STARTED_SCHEMA, JOB_STATUS_SCHEMA,
-    RESULT_SCHEMA, STATUS_SCHEMA,
-    Access, CapabilitiesResult, ConfigMode, Detail, Effort,
+    CAPABILITIES_SCHEMA, DRY_RUN_SCHEMA, FINGERPRINT, JOB_LIST_SCHEMA,
+    JOB_STARTED_SCHEMA, JOB_STATUS_SCHEMA, RESULT_SCHEMA, STATUS_SCHEMA,
+    Access, CapabilitiesResult, ConfigMode, Detail, DryRunResult, Effort,
     ErrorInfo, ErrorResult, JobStarted, Meta, ResolvedDefaults, Scope, StatusResult,
+    workspace_warning_for,
 )
 
 CAPABILITY_SUMMARY = (
     "cc-plugin-codex lets Codex ask Claude Code for bounded, independent critique: "
     "diff reviews, adversarial plan review, and second opinions. It never edits code, "
-    "runs shell, or proxies Claude MCP tools. Paid tools send prompt/code context to "
-    "Anthropic; call claude_status before spending to check CLI/auth/defaults. Use "
-    "claude_review_changes for blocking diff review and claude_review_changes_async "
-    "for background review with poll/result/cancel. Findings are advisory claims to "
-    "verify. workspace_root defaults to the first MCP root, then cwd; when roots are "
-    "available, explicit workspace_root must be inside one root. Use access=toolless "
-    "by default; access=readonly lets Claude read workspace files directly. The "
-    "surface is experimental; pin fingerprint from cc_codex_capabilities."
+    "runs shell, or proxies Claude MCP tools. Paid tools send code context to "
+    "Anthropic; call claude_status before spending. claude_review_changes blocks; "
+    "claude_review_changes_async runs in background with poll/result/cancel; "
+    "claude_review_dry_run previews workspace/diff-size/redaction for free. Findings "
+    "are advisory claims to verify. Pass workspace_root explicitly: it defaults to "
+    "the first MCP root, else the server's own cwd (likely NOT your repo); when roots "
+    "exist it must be inside one. access=toolless is the default; access=readonly "
+    "lets Claude read files directly, bypassing filename-based secret redaction. "
+    "Experimental; pin fingerprint from cc_codex_capabilities."
 )
 
 mcp = FastMCP(name="cc-plugin-codex", instructions=CAPABILITY_SUMMARY)
@@ -84,11 +86,14 @@ def _result(payload: dict) -> ToolResult:
 def _meta(cwd: str, config_mode: str, access: str, timeout: int, elapsed: int,
           exit_code: int | None, scope: str | None = None, base: str | None = None,
           truncated: bool = False, hint: str | None = None,
-          workspace_source: str | None = None) -> Meta:
+          workspace_source: str | None = None,
+          requested_budget: float | None = None) -> Meta:
     return Meta(cwd=cwd, config_mode=config_mode, access=access, scope=scope, base=base,
                 timeout_seconds=timeout, elapsed_ms=elapsed, command_exit_code=exit_code,
                 truncated=truncated, truncation_hint=hint, fingerprint=FINGERPRINT,
-                workspace_source=workspace_source)
+                workspace_source=workspace_source,
+                workspace_warning=workspace_warning_for(workspace_source, cwd),
+                requested_max_budget_usd=requested_budget)
 
 
 def _err(code: str, message: str, repair: str, meta: Meta,
@@ -212,18 +217,19 @@ def _resolve(config_mode, access, model, max_budget_usd, timeout_seconds, detail
     # would raise Pydantic errors before we can return a structured response).
     if cm not in ("inherit", "scoped", "bare"):
         safe_meta = _meta(cwd, "inherit", ac if ac in ("toolless", "readonly") else "toolless",
-                          timeout, 0, None, scope, base, workspace_source=workspace_source)
+                          timeout, 0, None, scope, base, workspace_source=workspace_source,
+                          requested_budget=budget)
         return None, _err("unsupported_config_mode", f"Unknown config_mode '{cm}'.",
                           "Use one of: inherit, scoped, bare.", safe_meta,
                           offending="config_mode")
     if ac not in ("toolless", "readonly"):
         safe_meta = _meta(cwd, cm, "toolless", timeout, 0, None, scope, base,
-                          workspace_source=workspace_source)
+                          workspace_source=workspace_source, requested_budget=budget)
         return None, _err("unsupported_access", f"Unknown access '{ac}'.",
                           "Use one of: toolless, readonly.", safe_meta, offending="access")
 
     meta = _meta(cwd, cm, ac, timeout, 0, None, scope, base,
-                 workspace_source=workspace_source)
+                 workspace_source=workspace_source, requested_budget=budget)
     if cm == "bare" and not bare_available():
         return None, _err("api_key_missing",
                           "config_mode=bare requires ANTHROPIC_API_KEY, which is unset.",
@@ -239,7 +245,7 @@ async def _execute(tool, payload, r: Resolved, cwd,
     cmd = build_command(prompt, r.config_mode, r.access, r.model, r.budget, r.effort)
     run = await run_claude_async(cmd, cwd=cwd, timeout_seconds=r.timeout)
     meta = _meta(cwd, r.config_mode, r.access, r.timeout, run.elapsed_ms, run.exit_code,
-                 scope, base, workspace_source=workspace_source)
+                 scope, base, workspace_source=workspace_source, requested_budget=r.budget)
     if run.exit_code != 0 or run.timed_out:
         # A non-zero exit can still carry a cost-bearing JSON envelope (e.g.
         # budget_exceeded); report what it spent when available.
@@ -336,7 +342,7 @@ async def claude_review_changes(
     if err:
         return _result(err)
     meta = _meta(cwd, r.config_mode, r.access, r.timeout, 0, None, scope, base,
-                 workspace_source=ws_source)
+                 workspace_source=ws_source, requested_budget=r.budget)
     try:
         ctx_data = await anyio.to_thread.run_sync(
             lambda: gather_context(cwd, scope=scope, base=base))
@@ -352,7 +358,8 @@ async def claude_review_changes(
                        "Ensure cwd is a git repo and base ref exists.", meta))
     if ctx_data.truncated:
         meta = _meta(cwd, r.config_mode, r.access, r.timeout, 0, None, scope, base,
-                     truncated=True, hint=ctx_data.truncation_hint, workspace_source=ws_source)
+                     truncated=True, hint=ctx_data.truncation_hint, workspace_source=ws_source,
+                     requested_budget=r.budget)
         return _result(_err("context_too_large", "The diff is too large to review safely.",
                        ctx_data.truncation_hint or "Narrow the scope.", meta))
     out = await _execute(
@@ -436,7 +443,8 @@ async def claude_adversarial_review(
 
 
 # Starting a background job commits to spend (the job runs to completion or its
-# budget cap even if never polled), but returns immediately without blocking.
+# best-effort budget stop threshold even if never polled), but returns immediately
+# without blocking.
 _ASYNC_START_ANNOTATIONS = {
     "readOnlyHint": False, "openWorldHint": True,
     "destructiveHint": False, "idempotentHint": False,
@@ -482,7 +490,7 @@ async def claude_review_changes_async(
     # timeout_seconds; report that everywhere so meta stays consistent with the job.
     job_timeout = jobs.max_seconds()
     meta = _meta(cwd, r.config_mode, r.access, job_timeout, 0, None, scope, base,
-                 workspace_source=ws_source)
+                 workspace_source=ws_source, requested_budget=r.budget)
     try:
         ctx_data = await anyio.to_thread.run_sync(
             lambda: gather_context(cwd, scope=scope, base=base))
@@ -498,7 +506,8 @@ async def claude_review_changes_async(
                        "Ensure cwd is a git repo and base ref exists.", meta))
     if ctx_data.truncated:
         meta = _meta(cwd, r.config_mode, r.access, job_timeout, 0, None, scope, base,
-                     truncated=True, hint=ctx_data.truncation_hint, workspace_source=ws_source)
+                     truncated=True, hint=ctx_data.truncation_hint, workspace_source=ws_source,
+                     requested_budget=r.budget)
         return _result(_err("context_too_large", "The diff is too large to review safely.",
                        ctx_data.truncation_hint or "Narrow the scope.", meta))
     prompt = build_prompt("claude_review_changes",
@@ -507,7 +516,7 @@ async def claude_review_changes_async(
     cfg = JobConfig(kind="claude_review_changes", config_mode=r.config_mode,
                     access=r.access, scope=scope, base=base, detail=r.detail,
                     timeout_seconds=jobs.max_seconds(), workspace_source=ws_source,
-                    context_summary=ctx_data.summary)
+                    context_summary=ctx_data.summary, requested_max_budget_usd=r.budget)
     job_id, started_at = await anyio.to_thread.run_sync(
         lambda: jobs.start_job(cmd, cwd, cfg))
     started = JobStarted(
@@ -516,7 +525,7 @@ async def claude_review_changes_async(
         poll_after_ms=jobs.poll_after_ms(),
         ttl_seconds=jobs.ttl_seconds(),
         meta=_meta(cwd, r.config_mode, r.access, job_timeout, 0, None, scope, base,
-                   workspace_source=ws_source),
+                   workspace_source=ws_source, requested_budget=r.budget),
     )
     return _result(started.model_dump(mode="json", exclude_none=True))
 
@@ -627,6 +636,75 @@ async def claude_job_cancel(
     return _result(data)
 
 
+@mcp.tool(annotations=_FREE_READ_ANNOTATIONS, title="Preview review context (no spend)",
+          output_schema=DRY_RUN_SCHEMA)
+async def claude_review_dry_run(
+    scope: Annotated[Scope, Field(description="working_tree|staged|branch")],
+    base: Annotated[str, Field(description="Base ref for scope=branch.")] = "main",
+    workspace_root: Annotated[Optional[str], Field(
+        description="Absolute path to the repo/workspace. If omitted, the server "
+        "uses the client's first MCP root, else its own cwd.")] = None,
+    ctx: Context = None,
+) -> ToolResult:
+    """Preview what a diff review WOULD send, free and without calling Claude.
+
+    Use before a paid claude_review_changes to confirm the resolved workspace,
+    diff byte size, whether it would be truncated, and how many secret-looking
+    files would be redacted. Read-only; makes no paid call.
+    """
+    cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
+    if ws_err:
+        return _result(_workspace_error(ws_err, workspace_root))
+    meta = _meta(cwd, "inherit", "toolless", 0, 0, None, scope, base,
+                 workspace_source=ws_source)
+    try:
+        ctx_data = await anyio.to_thread.run_sync(
+            lambda: gather_context(cwd, scope=scope, base=base))
+    except InvalidBaseError:
+        return _result(_err("invalid_base", f"Invalid base ref '{base}'.",
+                       "Use an existing git ref matching [A-Za-z0-9._/-]+ that does "
+                       "not start with '-'.", meta, offending="base"))
+    except InvalidScopeError:
+        return _result(_err("invalid_scope", f"Invalid scope '{scope}'.",
+                       "Use working_tree, staged, or branch.", meta, offending="scope"))
+    except RuntimeError as e:
+        return _result(_err("internal_error", f"git failed: {e}",
+                       "Ensure cwd is a git repo and base ref exists.", meta))
+    result = DryRunResult(
+        cwd=cwd, workspace_source=ws_source,
+        workspace_warning=workspace_warning_for(ws_source, cwd),
+        scope=scope, base=base,
+        context_summary=ctx_data.summary,
+        diff_bytes=ctx_data.diff_bytes,
+        max_diff_bytes=MAX_DIFF_BYTES,
+        truncated=ctx_data.truncated,
+        truncation_hint=ctx_data.truncation_hint,
+        redacted_paths_count=len(ctx_data.redacted_paths),
+        redacted_paths=ctx_data.redacted_paths,
+    )
+    return _result(result.model_dump(mode="json", exclude_none=True))
+
+
+@mcp.tool(annotations=_LOCAL_MUTATION_ANNOTATIONS, title="List background jobs",
+          output_schema=JOB_LIST_SCHEMA)
+async def claude_job_list(
+    workspace_root: Annotated[Optional[str], Field(
+        description="Workspace whose jobs to list (defaults like the async tools).")] = None,
+    ctx: Context = None,
+) -> ToolResult:
+    """List the background review jobs known for this workspace, newest first.
+
+    Use to recover job_ids lost across context compaction or interruption. Returns
+    each job's id, kind, status, start time, result_available, expiry, and cost when
+    terminal. Like the other lifecycle tools it refreshes statuses (not read-only).
+    """
+    cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
+    if ws_err:
+        return _result(_workspace_error(ws_err, workspace_root))
+    data = await anyio.to_thread.run_sync(lambda: jobs.list_jobs(cwd))
+    return _result(data)
+
+
 @mcp.tool(annotations=_FREE_READ_ANNOTATIONS, title="Claude CLI status & defaults",
           output_schema=STATUS_SCHEMA)
 def claude_status() -> ToolResult:
@@ -678,15 +756,9 @@ def claude_status() -> ToolResult:
     return _result(status.model_dump(mode="json", exclude_none=True))
 
 
-@mcp.tool(annotations=_FREE_READ_ANNOTATIONS, title="cc-plugin-codex capabilities",
-          output_schema=CAPABILITIES_SCHEMA)
-def cc_codex_capabilities() -> ToolResult:
-    """Return the compact capability contract for this server.
-
-    Free and read-only. Call first when unsure which tool to use. Includes tool
-    inventory, scope/negative-scope, prerequisites, modes, deprecation policy, and
-    fingerprint.
-    """
+def _capabilities_payload() -> dict:
+    """Build the capability contract. Shared by cc_codex_capabilities and its
+    claude_capabilities alias so the two tools cannot drift."""
     result = CapabilitiesResult(
         name="cc-plugin-codex",
         version=__version__,
@@ -694,9 +766,9 @@ def cc_codex_capabilities() -> ToolResult:
         stability="experimental",
         paid_tools=["claude_ask", "claude_review_changes", "claude_adversarial_review",
                     "claude_review_changes_async"],
-        free_tools=["claude_status", "cc_codex_capabilities", "claude_job_status",
-                    "claude_job_result", "claude_job_consume_result",
-                    "claude_job_cancel"],
+        free_tools=["claude_status", "cc_codex_capabilities", "claude_capabilities",
+                    "claude_review_dry_run", "claude_job_status", "claude_job_result",
+                    "claude_job_consume_result", "claude_job_cancel", "claude_job_list"],
         config_modes=["inherit", "scoped", "bare"],
         access_modes=["toolless", "readonly"],
         scope=[
@@ -704,12 +776,15 @@ def cc_codex_capabilities() -> ToolResult:
             "adversarial review of a plan/claim",
             "a free-form independent second opinion",
             "background diff review with poll/result/cancel for long runs",
+            "a free dry-run preview of workspace, diff size, and redaction before paying",
         ],
         negative_scope=[
             "does NOT edit code or run shell",
             "does NOT act as a general Claude chat",
             "does NOT proxy Claude's own MCP tools",
             "does NOT resume a call once it ends or is cancelled",
+            "does NOT content-scan for secrets; with access=readonly Claude can read "
+            "workspace files directly, bypassing filename-based redaction",
         ],
         prerequisites=[
             "the `claude` CLI installed and authenticated",
@@ -722,7 +797,38 @@ def cc_codex_capabilities() -> ToolResult:
             "bump the fingerprint."
         ),
     )
-    return _result(result.model_dump(mode="json", exclude_none=True))
+    return result.model_dump(mode="json", exclude_none=True)
+
+
+_CAPABILITIES_DOC = (
+    "Return the compact capability contract for this server: tool inventory (review, "
+    "second opinion, adversarial critique), scope/negative-scope, prerequisites, modes, "
+    "deprecation policy, and fingerprint.\n\n"
+    "Free and read-only. Call first when unsure which Claude review tool to use."
+)
+
+
+@mcp.tool(annotations=_FREE_READ_ANNOTATIONS, title="cc-plugin-codex capabilities",
+          output_schema=CAPABILITIES_SCHEMA)
+def cc_codex_capabilities() -> ToolResult:
+    """Return the compact capability contract for this server.
+
+    Free and read-only. Call first when unsure which tool to use. Includes tool
+    inventory, scope/negative-scope, prerequisites, modes, deprecation policy, and
+    fingerprint. Also available as claude_capabilities.
+    """
+    return _result(_capabilities_payload())
+
+
+@mcp.tool(annotations=_FREE_READ_ANNOTATIONS, title="Claude review capabilities",
+          output_schema=CAPABILITIES_SCHEMA)
+def claude_capabilities() -> ToolResult:
+    """Alias of cc_codex_capabilities: the Claude review/critique capability contract.
+
+    Free and read-only. Discoverable under a claude_* name; returns the identical
+    contract as cc_codex_capabilities.
+    """
+    return _result(_capabilities_payload())
 
 
 @mcp.resource("cc-plugin-codex://capabilities")

--- a/plugins/cc-plugin-codex/tests/test_context.py
+++ b/plugins/cc-plugin-codex/tests/test_context.py
@@ -14,6 +14,19 @@ def test_working_tree_diff(git_repo):
     assert res.summary.files_changed == 1
     assert res.summary.lines_added >= 1
     assert res.truncated is False
+    assert res.diff_bytes == len(res.text.encode("utf-8"))
+
+
+def test_diff_bytes_reports_full_size_when_truncated(git_repo, monkeypatch):
+    import cc_plugin_codex.context as ctx
+    monkeypatch.setattr(ctx, "MAX_DIFF_BYTES", 10)
+    (git_repo / "big.py").write_text("x = 1\n" * 1000)
+    subprocess.run(["git", "add", "-Nf", "big.py"], cwd=git_repo, check=True)
+    res = gather_context(str(git_repo), scope="working_tree", base="main")
+    assert res.truncated is True
+    # diff_bytes is the true (pre-truncation) size, not the clipped text length.
+    assert res.diff_bytes > 10
+    assert len(res.text.encode("utf-8")) <= 10
 
 
 def test_invalid_scope(git_repo):

--- a/plugins/cc-plugin-codex/tests/test_jobs.py
+++ b/plugins/cc-plugin-codex/tests/test_jobs.py
@@ -82,6 +82,19 @@ def test_job_done_returns_normalized_result(tmp_path):
     assert payload["meta"]["cost_usd"] == 0.0123
 
 
+def test_job_meta_carries_requested_budget_and_warning(tmp_path):
+    cwd = str(tmp_path)
+    job_id, _ = jobs.start_job(
+        _emit_cmd(), cwd,
+        _cfg(workspace_source="cwd", requested_max_budget_usd=0.30))
+    _await_done(cwd, job_id)
+    payload, found = jobs.result(cwd, job_id)
+    assert found is True
+    assert payload["meta"]["requested_max_budget_usd"] == 0.30
+    # workspace_source=cwd must surface the footgun warning on the rebuilt job meta.
+    assert "workspace_root" in payload["meta"]["workspace_warning"]
+
+
 def test_job_running_then_result_says_job_running(tmp_path):
     cwd = str(tmp_path)
     job_id, _ = jobs.start_job(_sleep_cmd(), cwd, _cfg())

--- a/plugins/cc-plugin-codex/tests/test_jobs.py
+++ b/plugins/cc-plugin-codex/tests/test_jobs.py
@@ -95,6 +95,30 @@ def test_job_meta_carries_requested_budget_and_warning(tmp_path):
     assert "workspace_root" in payload["meta"]["workspace_warning"]
 
 
+def test_terminal_nondone_job_surfaces_cost(tmp_path):
+    # A cancelled/timeout job can still have left a cost-bearing envelope. status()
+    # and list_jobs() must surface that spend, matching the result path and the
+    # JobStatus.cost_usd contract ("terminal jobs that spent"), not only done jobs.
+    cwd = str(tmp_path)
+    job_id, _ = jobs.start_job(_emit_cmd(), cwd, _cfg())
+    _await_done(cwd, job_id)
+    # Simulate a cancel that raced in after the envelope landed: the envelope (with
+    # its cost) is on disk, but the record is marked terminal-cancelled.
+    jd = jobs._job_dir(cwd, job_id)
+    meta = jobs._read_meta(jd)
+    meta["terminal_status"] = "cancelled"
+    jobs._write_meta(jd, meta)
+
+    st = jobs.status(cwd, job_id)
+    assert st["status"] == "cancelled"
+    assert st["cost_usd"] == 0.0123
+
+    listing = jobs.list_jobs(cwd)
+    job = next(j for j in listing["jobs"] if j["job_id"] == job_id)
+    assert job["status"] == "cancelled"
+    assert job["cost_usd"] == 0.0123
+
+
 def test_job_running_then_result_says_job_running(tmp_path):
     cwd = str(tmp_path)
     job_id, _ = jobs.start_job(_sleep_cmd(), cwd, _cfg())

--- a/plugins/cc-plugin-codex/tests/test_schemas.py
+++ b/plugins/cc-plugin-codex/tests/test_schemas.py
@@ -38,7 +38,7 @@ def test_success_result_has_next_steps():
 
 
 def test_fingerprint_value():
-    assert FINGERPRINT == "cc-plugin-codex/0.1/schema-8"
+    assert FINGERPRINT == "cc-plugin-codex/0.1/schema-9"
 
 
 def test_success_result_dump_omits_none():

--- a/plugins/cc-plugin-codex/tests/test_server.py
+++ b/plugins/cc-plugin-codex/tests/test_server.py
@@ -199,7 +199,7 @@ async def test_claude_ask_returns_normalized(fake_claude):
     data = structured(result)
     assert data["ok"] is True
     assert data["verdict"] == "concerns"
-    assert data["meta"]["fingerprint"] == "cc-plugin-codex/0.1/schema-8"
+    assert data["meta"]["fingerprint"] == "cc-plugin-codex/0.1/schema-9"
 
 
 async def test_invalid_enum_param_rejected_by_schema(fake_claude):
@@ -554,7 +554,7 @@ async def test_capabilities_tool_returns_structured_contract():
     async with Client(mcp) as client:
         result = await client.call_tool("cc_codex_capabilities", {})
     data = structured(result)
-    assert data["fingerprint"] == "cc-plugin-codex/0.1/schema-8"
+    assert data["fingerprint"] == "cc-plugin-codex/0.1/schema-9"
     assert data["transport"] == "stdio"
     assert set(data["paid_tools"]) == {
         "claude_ask", "claude_review_changes", "claude_adversarial_review",
@@ -566,6 +566,150 @@ async def test_capabilities_tool_returns_structured_contract():
     assert data["negative_scope"]            # non-empty list of what it won't do
     assert data["prerequisites"]
     assert "fingerprint" in data["deprecation_policy"]
+
+
+async def test_list_tools_includes_new_free_tools():
+    names = set(await _tools_by_name())
+    assert {"claude_review_dry_run", "claude_job_list", "claude_capabilities"} <= names
+
+
+async def test_claude_capabilities_alias_matches_canonical():
+    async with Client(mcp) as client:
+        canon = structured(await client.call_tool("cc_codex_capabilities", {}))
+        alias = structured(await client.call_tool("claude_capabilities", {}))
+    # request_id-free contract: the two must be byte-for-byte identical.
+    assert canon == alias
+    assert "claude_review_dry_run" in alias["free_tools"]
+    assert "claude_job_list" in alias["free_tools"]
+    # The readonly redaction-bypass caveat is now in the negative scope.
+    assert any("readonly" in s for s in alias["negative_scope"])
+
+
+async def test_dry_run_previews_without_spending(monkeypatch, git_repo):
+    # No fake_claude: a real paid call would fail. The dry-run must not call Claude.
+    monkeypatch.chdir(git_repo)
+    async with Client(mcp) as client:
+        data = structured(await client.call_tool(
+            "claude_review_dry_run",
+            {"scope": "working_tree", "workspace_root": str(git_repo)}))
+    assert data["ok"] is True
+    assert data["tool"] == "claude_review_dry_run"
+    assert data["cwd"] == str(git_repo)
+    assert data["workspace_source"] == "param"
+    assert data["diff_bytes"] > 0
+    assert data["max_diff_bytes"] > 0
+    assert data["truncated"] is False
+    assert data["context_summary"]["files_changed"] == 1
+    assert "fingerprint" in data
+
+
+async def test_dry_run_reports_redaction_count(monkeypatch, git_repo):
+    import subprocess as _sp
+    (git_repo / ".env").write_text("API_KEY=supersecret\n")
+    _sp.run(["git", "add", "-Nf", ".env"], cwd=git_repo, check=True)
+    async with Client(mcp) as client:
+        data = structured(await client.call_tool(
+            "claude_review_dry_run",
+            {"scope": "working_tree", "workspace_root": str(git_repo)}))
+    assert data["redacted_paths_count"] >= 1
+    assert any(".env" in p for p in data["redacted_paths"])
+
+
+async def test_dry_run_bad_base_is_structured_error(git_repo):
+    async with Client(mcp) as client:
+        data = structured(await client.call_tool(
+            "claude_review_dry_run",
+            {"scope": "branch", "base": "-badref", "workspace_root": str(git_repo)},
+            raise_on_error=False))
+    assert data["ok"] is False
+    assert data["error"]["code"] == "invalid_base"
+
+
+async def test_cwd_resolution_sets_workspace_warning(fake_claude, monkeypatch, git_repo):
+    # When the workspace falls back to cwd (no param, no roots), the success meta
+    # must carry workspace_warning so an agent can notice the footgun.
+    monkeypatch.chdir(git_repo)
+    async with Client(mcp) as client:
+        data = structured(await client.call_tool(
+            "claude_review_changes", {"scope": "working_tree"}))
+    assert data["ok"] is True
+    assert data["meta"]["workspace_source"] == "cwd"
+    assert "workspace_root" in data["meta"]["workspace_warning"]
+
+
+async def test_param_resolution_has_no_workspace_warning(fake_claude, git_repo):
+    async with Client(mcp) as client:
+        data = structured(await client.call_tool(
+            "claude_review_changes",
+            {"scope": "working_tree", "workspace_root": str(git_repo)}))
+    assert data["ok"] is True
+    assert "workspace_warning" not in data["meta"]  # None is dropped by exclude_none
+
+
+async def test_meta_echoes_requested_budget(fake_claude, monkeypatch, git_repo):
+    monkeypatch.chdir(git_repo)
+    async with Client(mcp) as client:
+        data = structured(await client.call_tool(
+            "claude_ask", {"prompt": "x", "max_budget_usd": 0.25}))
+    assert data["meta"]["requested_max_budget_usd"] == 0.25
+
+
+async def test_status_auth_detail_is_redacted(monkeypatch):
+    # claude_status must not leak the account email/org from `claude auth status`.
+    import cc_plugin_codex.claude as cl
+
+    class _Proc:
+        returncode = 0
+        stdout = "Logged in as alice@example.com (org: Acme Corp)"
+        stderr = ""
+
+    monkeypatch.setattr(cl.subprocess, "run", lambda *a, **k: _Proc())
+    logged_in, detail = cl.auth_status()
+    assert logged_in is True
+    assert detail and "alice@example.com" not in detail
+    assert "Acme Corp" not in detail
+
+
+async def test_job_list_recovers_job_ids(monkeypatch, git_repo, tmp_path):
+    import json as _json
+    import time as _time
+
+    import cc_plugin_codex.server as srv
+
+    monkeypatch.setenv("CC_PLUGIN_CODEX_STATE_DIR", str(tmp_path / "state"))
+    inner = {"summary": "ok", "verdict": "pass", "confidence": "high",
+             "findings": [], "questions": [], "assumptions": []}
+    envelope = _json.dumps({"type": "result", "subtype": "success", "is_error": False,
+                            "result": _json.dumps(inner), "total_cost_usd": 0.02})
+    monkeypatch.setattr(srv, "build_command",
+                        lambda *a, **k: ["sh", "-c", "printf '%s' \"$0\"", envelope])
+
+    async with Client(mcp) as client:
+        empty = structured(await client.call_tool(
+            "claude_job_list", {"workspace_root": str(git_repo)}))
+        assert empty["jobs"] == []
+
+        started = structured(await client.call_tool(
+            "claude_review_changes_async",
+            {"scope": "working_tree", "workspace_root": str(git_repo)}))
+        job_id = started["job_id"]
+        deadline = _time.time() + 5
+        while _time.time() < deadline:
+            st = structured(await client.call_tool(
+                "claude_job_status",
+                {"job_id": job_id, "workspace_root": str(git_repo)}))
+            if st["status"] == "done":
+                break
+            await anyio.sleep(0.05)
+
+        listing = structured(await client.call_tool(
+            "claude_job_list", {"workspace_root": str(git_repo)}))
+    assert listing["ok"] is True
+    ids = [j["job_id"] for j in listing["jobs"]]
+    assert job_id in ids
+    job = next(j for j in listing["jobs"] if j["job_id"] == job_id)
+    assert job["status"] == "done"
+    assert job["result_available"] is True
 
 
 async def test_paid_failure_reports_cost_on_error_meta(monkeypatch):

--- a/plugins/cc-plugin-codex/uv.lock
+++ b/plugins/cc-plugin-codex/uv.lock
@@ -148,7 +148,7 @@ wheels = [
 
 [[package]]
 name = "cc-plugin-codex"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Hardens the `cc-plugin-codex` MCP server so agents (Codex) can discover, predict, and safely use its Claude-review tools. The branch tightens the agent contract, adds prek hooks managed by uv, and acts on a structured agent evaluation — with an independent review pass from Codex.

## Highlights (latest commit — evaluation findings)

Driven by `docs/cc-plugin-codex-evaluation-scenarios.md` and planned in `docs/cc-plugin-codex-action-plan.md`:

- **Workspace footgun** — surface `meta.workspace_warning` when the workspace falls back to the server's own cwd, so a review never silently targets the wrong repo unnoticed.
- **Free dry-run** — new `claude_review_dry_run` previews resolved workspace, diff byte size, truncation, and redaction count before any paid call. `gather_context` now exposes `diff_bytes`.
- **Auth privacy** — `claude auth status` output is redacted to a non-identifying phrase (no account email/org leaks into logs).
- **Budget honesty** — add `meta.requested_max_budget_usd`; reword "cap" → best-effort "stop threshold" across code, errors, skill, and README (reported cost can exceed the requested value).
- **Job recovery** — `claude_job_list` recovers job ids lost across context compaction.
- **Redaction caveat** — document that `access=readonly` lets Claude read files directly, bypassing filename-based redaction (skill + capability negative-scope).
- **Discovery** — `claude_capabilities` alias of `cc_codex_capabilities` via a shared helper, plus discovery keywords in the capability summary.
- **Docs** — make `workspace_root` prominent and give realistic budget guidance.

Bumps `FINGERPRINT` `schema-8` → `schema-9` and the plugin version `0.1.1` → `0.1.2`.

## Earlier commits on the branch

- Tighten the agent contract and address prior PR feedback.
- Correct background-job tool annotations.
- Add cc-plugin-codex prek hooks, managed with uv.

## Testing

- `uv run pytest` → **135 passed** (12 new, covering dry-run, job-list, alias parity, workspace_warning presence/absence, budget echo, auth redaction, and diff_bytes).
- `uv run ruff check .` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)