### PR TITLE
Fix cc-plugin-codex robustness backlog

### DIFF
--- a/.github/workflows/cc-plugin-codex-ci.yml
+++ b/.github/workflows/cc-plugin-codex-ci.yml
@@ -1,0 +1,77 @@
+name: cc-plugin-codex CI
+
+on:
+  pull_request:
+    paths:
+      - "plugins/cc-plugin-codex/**"
+      - ".github/workflows/cc-plugin-codex-ci.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "plugins/cc-plugin-codex/**"
+      - ".github/workflows/cc-plugin-codex-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Ruff and pytest
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugins/cc-plugin-codex
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: plugins/cc-plugin-codex/uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Sync dependencies
+        run: uv sync --group dev
+
+      - name: Lint
+        run: uv run ruff check src tests
+
+      - name: Test
+        run: uv run pytest -q
+
+  live-integration:
+    name: Live Claude integration
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugins/cc-plugin-codex
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: plugins/cc-plugin-codex/uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Sync dependencies
+        run: uv sync --group dev
+
+      - name: Run integration tests
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: uv run pytest -q tests/test_integration.py

--- a/plugins/cc-plugin-codex/README.md
+++ b/plugins/cc-plugin-codex/README.md
@@ -41,6 +41,8 @@ logged-out CLI before paying for a call that would only then fail auth),
 combined `ready` flag.
 Every paid result also reports `meta.cost_usd` and `meta.usage` (token counts) so an
 agent can track actual spend across calls.
+Diff-bearing paid results report `meta.redacted_paths` when the server withheld or
+masked content before sending it to Claude.
 
 ## Requirements
 
@@ -91,7 +93,8 @@ plugin install) so reviews target your project rather than the plugin checkout.
 
 - Read-only: Claude is never given write or Bash tools.
 - Secret redaction is filename-based (`.env`, `*.env`, `*.pem`, `*.key`, key files), not
-  content-scanning — it will not catch secrets hardcoded inside ordinary source files.
+  plus conservative content scanning for high-confidence token/key patterns in added
+  diff lines. Treat it as defense-in-depth, not a guarantee.
 - Diff redaction only applies to the context the server gathers. With `access=readonly`,
   Claude can read any file in the workspace directly (`Read`/`Grep`/`Glob`), so redaction
   does NOT protect against secrets it reads itself — use `access=toolless` (the default)
@@ -102,6 +105,15 @@ plugin install) so reviews target your project rather than the plugin checkout.
   threshold (enforced by the Claude CLI), not a hard cap — reported `meta.cost_usd` can
   exceed it; `meta.requested_max_budget_usd` echoes the value sent. `timeout_seconds`
   bounds wall-clock time per call.
+- Free-form text inputs (`prompt`/`context` for `claude_ask`, `target`/`evidence` for
+  `claude_adversarial_review`) are capped before a paid call by
+  `CC_PLUGIN_CODEX_MAX_INPUT_BYTES` (default 200000 bytes).
+- Git context collection is bounded by `CC_PLUGIN_CODEX_GIT_TIMEOUT_SECONDS` (default
+  60s), so preflight diff work cannot hang indefinitely.
+
+If a requested diff scope has no changes, the review tools return `ok:true` with a
+`pass` verdict and a "No changes in scope" summary without invoking Claude or starting
+a background job.
 
 ## Background reviews
 
@@ -141,7 +153,8 @@ unrecognized `CC_PLUGIN_CODEX_EFFORT` env value instead falls back to the defaul
 
 `CC_PLUGIN_CODEX_CLAUDE_CONFIG`, `CC_PLUGIN_CODEX_ACCESS`, `CC_PLUGIN_CODEX_MODEL`,
 `CC_PLUGIN_CODEX_EFFORT`, `CC_PLUGIN_CODEX_MAX_BUDGET_USD`,
-`CC_PLUGIN_CODEX_TIMEOUT_SECONDS`, `ANTHROPIC_API_KEY`.
+`CC_PLUGIN_CODEX_TIMEOUT_SECONDS`, `CC_PLUGIN_CODEX_MAX_INPUT_BYTES`,
+`CC_PLUGIN_CODEX_GIT_TIMEOUT_SECONDS`, `ANTHROPIC_API_KEY`.
 
 Background jobs add: `CC_PLUGIN_CODEX_STATE_DIR`, `CC_PLUGIN_CODEX_JOB_MAX_SECONDS`,
 `CC_PLUGIN_CODEX_JOB_TTL`, `CC_PLUGIN_CODEX_JOB_MAX_COUNT`.

--- a/plugins/cc-plugin-codex/README.md
+++ b/plugins/cc-plugin-codex/README.md
@@ -92,9 +92,9 @@ plugin install) so reviews target your project rather than the plugin checkout.
 ## Safety
 
 - Read-only: Claude is never given write or Bash tools.
-- Secret redaction is filename-based (`.env`, `*.env`, `*.pem`, `*.key`, key files), not
-  plus conservative content scanning for high-confidence token/key patterns in added
-  diff lines. Treat it as defense-in-depth, not a guarantee.
+- Secret redaction combines filename-based rules (`.env`, `*.env`, `*.pem`, `*.key`,
+  key files) with conservative content scanning for high-confidence token/key patterns
+  in gathered diff lines. Treat it as defense-in-depth, not a guarantee.
 - Diff redaction only applies to the context the server gathers. With `access=readonly`,
   Claude can read any file in the workspace directly (`Read`/`Grep`/`Glob`), so redaction
   does NOT protect against secrets it reads itself — use `access=toolless` (the default)

--- a/plugins/cc-plugin-codex/skills/collaborating-with-claude/SKILL.md
+++ b/plugins/cc-plugin-codex/skills/collaborating-with-claude/SKILL.md
@@ -30,7 +30,7 @@ Do NOT call Claude in a loop, and never call Claude just because Claude suggeste
 - `claude_review_changes_async` — same review as a background job for large diffs or when you want to keep working; returns a `job_id`. Poll `claude_job_status`, then `claude_job_result` (same envelope as the sync tool). Use `claude_job_consume_result` only when you want to fetch and delete the stored record; use `claude_job_cancel` to stop it.
 - `claude_adversarial_review` — Claude attacks a plan/claim and lists the strongest counterarguments.
 - `claude_status` — free readiness check: reports whether `claude` is installed, authenticated (`claude_authenticated`), version-compatible (`version_supported`), and overall `ready`, plus the resolved defaults a no-arg call would use. Run it first if a call fails, or to confirm readiness before spending.
-- `claude_review_dry_run` — free preview of what a diff review would send: resolved workspace, diff byte size, whether it would be truncated, and how many secret-looking files would be redacted. No paid call. Run it before a large review to confirm scope and workspace.
+- `claude_review_dry_run` — free preview of what a diff review would send: resolved workspace, diff byte size, whether it would be truncated, and which paths would be redacted. No paid call. Run it before a large review to confirm scope and workspace.
 - `claude_job_list` — free list of this workspace's background jobs (id, status, cost), newest first. Use it to recover a `job_id` lost across context compaction or interruption.
 - `cc_codex_capabilities` (alias `claude_capabilities`) — free capability contract: tool inventory, scope, prerequisites, and the fingerprint to pin.
 
@@ -45,8 +45,9 @@ Do NOT call Claude in a loop, and never call Claude just because Claude suggeste
 
 - Each call is PAID and sends your code/diff to Anthropic. Call deliberately. Even a one-sentence `claude_ask` costs roughly `$0.02`; a real review costs more, so budgets below ~`$0.05` will usually trip `budget_exceeded`.
 - `max_budget_usd` is a best-effort stop threshold enforced by the Claude CLI, NOT a hard cap — reported `meta.cost_usd` can exceed it. `meta.requested_max_budget_usd` echoes the value sent so you can compare requested vs actual.
-- The server never sends `.env`/secret files in the diff it gathers; redaction is filename-based, not content-scanning, so do not paste secrets into prompts and do not rely on it to catch secrets hardcoded inside ordinary source files.
+- The server redacts `.env`/secret-looking files and high-confidence token/key patterns in added diff lines before sending gathered diff context. Treat this as best-effort defense-in-depth, not a guarantee; paid results expose affected paths in `meta.redacted_paths`.
 - Diff redaction only covers the context the server gathers. With `access=readonly`, Claude can `Read`/`Grep`/`Glob` any file in the workspace directly, so redaction does NOT protect against secrets it reads itself — use `access=toolless` (the default) when the workspace may contain secrets.
+- Free-form `prompt`/`context`/`target`/`evidence` text is capped before spend; split very large asks or use a narrower diff scope.
 - Default access is `toolless` (Claude gets no tools) and `config_mode=inherit`; both access modes are read-only (Claude never gets write/Bash). Use `config_mode=bare` only when you want a fully independent reviewer and have `ANTHROPIC_API_KEY` set.
 - When client MCP roots are available, explicit `workspace_root` values must be inside one of those roots; omit `workspace_root` to use the first root.
 - Cap cost/time with `max_budget_usd` and `timeout_seconds` for large reviews.

--- a/plugins/cc-plugin-codex/skills/collaborating-with-claude/SKILL.md
+++ b/plugins/cc-plugin-codex/skills/collaborating-with-claude/SKILL.md
@@ -45,7 +45,7 @@ Do NOT call Claude in a loop, and never call Claude just because Claude suggeste
 
 - Each call is PAID and sends your code/diff to Anthropic. Call deliberately. Even a one-sentence `claude_ask` costs roughly `$0.02`; a real review costs more, so budgets below ~`$0.05` will usually trip `budget_exceeded`.
 - `max_budget_usd` is a best-effort stop threshold enforced by the Claude CLI, NOT a hard cap — reported `meta.cost_usd` can exceed it. `meta.requested_max_budget_usd` echoes the value sent so you can compare requested vs actual.
-- The server redacts `.env`/secret-looking files and high-confidence token/key patterns in added diff lines before sending gathered diff context. Treat this as best-effort defense-in-depth, not a guarantee; paid results expose affected paths in `meta.redacted_paths`.
+- The server redacts `.env`/secret-looking files and high-confidence token/key patterns in gathered diff lines before sending context. Treat this as best-effort defense-in-depth, not a guarantee; paid results expose affected paths in `meta.redacted_paths`.
 - Diff redaction only covers the context the server gathers. With `access=readonly`, Claude can `Read`/`Grep`/`Glob` any file in the workspace directly, so redaction does NOT protect against secrets it reads itself — use `access=toolless` (the default) when the workspace may contain secrets.
 - Free-form `prompt`/`context`/`target`/`evidence` text is capped before spend; split very large asks or use a narrower diff scope.
 - Default access is `toolless` (Claude gets no tools) and `config_mode=inherit`; both access modes are read-only (Claude never gets write/Bash). Use `config_mode=bare` only when you want a fully independent reviewer and have `ANTHROPIC_API_KEY` set.

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/claude.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/claude.py
@@ -120,13 +120,11 @@ async def run_claude_async(cmd: list[str], cwd: str, timeout_seconds: int) -> Cl
 
 
 def classify_failure(run: ClaudeRun) -> ErrorInfo:
-    extra = ""
+    env = None
     try:
         env = json.loads(run.stdout)
-        extra = f"{env.get('subtype', '')} {env.get('result', '')}"
     except (json.JSONDecodeError, ValueError, TypeError):
         pass
-    blob = f"{extra}\n{run.stdout}\n{run.stderr}".lower()
     if run.stderr == "claude_not_found":
         return ErrorInfo(code="claude_not_found",
                          message="The `claude` CLI was not found on PATH.",
@@ -135,6 +133,39 @@ def classify_failure(run: ClaudeRun) -> ErrorInfo:
         return ErrorInfo(code="timeout", message="claude exceeded the timeout.",
                          repair="Narrow the scope/focus or raise timeout_seconds.",
                          retryable=True)
+    if isinstance(env, dict) and env.get("is_error"):
+        subtype = str(env.get("subtype") or "").lower()
+        result = str(env.get("result") or "")
+        structured_blob = f"{subtype}\n{result}".lower()
+        if "api_key" in structured_blob or "invalid api key" in structured_blob:
+            return ErrorInfo(code="api_key_invalid",
+                             message="ANTHROPIC_API_KEY is invalid.",
+                             repair="Set a valid ANTHROPIC_API_KEY, or use config_mode "
+                                    "inherit/scoped to use your existing login.")
+        if "auth" in structured_blob or "login" in structured_blob:
+            return ErrorInfo(code="claude_auth_required",
+                             message="claude is not authenticated.",
+                             repair="Run `claude /login`.")
+        if "budget" in structured_blob:
+            return ErrorInfo(code="budget_exceeded",
+                             message="claude reached the max-budget stop threshold "
+                                     "(a best-effort limit, not a hard cap).",
+                             repair="Raise max_budget_usd or reduce context.",
+                             retryable=True)
+        if "permission" in structured_blob or "denied" in structured_blob:
+            return ErrorInfo(code="claude_permission_error",
+                             message="claude was denied a requested permission.",
+                             repair="Use access=toolless, or allow the needed read-only tools.")
+        if "rate" in structured_blob or "overloaded" in structured_blob:
+            return ErrorInfo(code="nonzero_exit",
+                             message=f"claude reported a retryable error: {result[:200]}",
+                             repair="Retry later, or reduce request size.",
+                             retryable=True)
+
+    extra = ""
+    if isinstance(env, dict):
+        extra = f"{env.get('subtype', '')} {env.get('result', '')}"
+    blob = f"{extra}\n{run.stdout}\n{run.stderr}".lower()
     if "invalid api key" in blob:
         return ErrorInfo(code="api_key_invalid",
                          message="ANTHROPIC_API_KEY is invalid.",

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/config.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/config.py
@@ -10,6 +10,8 @@ EMPTY_MCP = '{"mcpServers":{}}'
 
 MIN_BUDGET_USD, MAX_BUDGET_USD = 0.01, 5.00
 MIN_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS = 10, 600
+DEFAULT_MAX_INPUT_BYTES = 200_000
+DEFAULT_GIT_TIMEOUT_SECONDS = 60
 
 # Reasoning effort levels the `claude` CLI accepts for `--effort`. We default to
 # a high level because the whole value of this server is review depth; lower it
@@ -106,6 +108,15 @@ def clamp_budget(value: float) -> float:
 
 def clamp_timeout(value: int) -> int:
     return max(MIN_TIMEOUT_SECONDS, min(MAX_TIMEOUT_SECONDS, value))
+
+
+def max_input_bytes() -> int:
+    return max(1_000, _env_int("CC_PLUGIN_CODEX_MAX_INPUT_BYTES", DEFAULT_MAX_INPUT_BYTES))
+
+
+def git_timeout_seconds() -> int:
+    return max(1, _env_int("CC_PLUGIN_CODEX_GIT_TIMEOUT_SECONDS",
+                           DEFAULT_GIT_TIMEOUT_SECONDS))
 
 
 def bare_available() -> bool:

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/context.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/context.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import re
+import shlex
 import subprocess
 from dataclasses import dataclass, field
 
+from cc_plugin_codex.config import git_timeout_seconds
 from cc_plugin_codex.schemas import ContextSummary
 
 MAX_DIFF_BYTES = 200_000
@@ -31,6 +33,15 @@ SECRET_PATH_RE = re.compile(
     re.IGNORECASE,
 )
 
+SECRET_VALUE_PATTERNS = [
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}"),
+    re.compile(r"xox[baprs]-[A-Za-z0-9-]{20,}"),
+    re.compile(r"(?i)(Authorization:\s*Bearer\s+)[A-Za-z0-9._~+/=-]{16,}"),
+    re.compile(r"(?i)((?:api|access|secret|private)?_?(?:key|token|secret)\s*[:=]\s*['\"]?)[A-Za-z0-9._~+/=-]{16,}"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+]
+
 
 @dataclass
 class ContextResult:
@@ -43,7 +54,14 @@ class ContextResult:
 
 
 def _git(cwd: str, *args: str) -> str:
-    proc = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+    timeout = git_timeout_seconds()
+    try:
+        proc = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True,
+                              timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"git {' '.join(args)} timed out after {timeout}s"
+        ) from exc
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or "git failed")
     return proc.stdout
@@ -80,20 +98,57 @@ def _summary(cwd: str, diff_args: list[str]) -> ContextSummary:
     return ContextSummary(files_changed=files, lines_added=added, lines_removed=removed)
 
 
+def _diff_path_from_header(line: str) -> str:
+    spec = line[len("diff --git "):]
+    try:
+        parts = shlex.split(spec)
+    except ValueError:
+        parts = spec.split()
+    if len(parts) >= 2:
+        path = parts[1]
+        return path[2:] if path.startswith("b/") else path
+    return spec
+
+
+def _redact_secret_values(line: str) -> tuple[str, bool]:
+    redacted = False
+    out = line
+    for pattern in SECRET_VALUE_PATTERNS:
+        def repl(match: re.Match) -> str:
+            nonlocal redacted
+            redacted = True
+            if match.lastindex:
+                return f"{match.group(1)}[redacted: secret value]"
+            return "[redacted: secret value]"
+        out = pattern.sub(repl, out)
+    return out, redacted
+
+
 def _redact(diff: str) -> tuple[str, list[str]]:
     out_lines: list[str] = []
     redacted: list[str] = []
     skipping = False
+    current_path = ""
     for line in diff.splitlines():
         if line.startswith("diff --git "):
             spec = line[len("diff --git "):]  # "a/<path> b/<path>" (paths may be quoted)
+            current_path = _diff_path_from_header(line)
             skipping = bool(SECRET_PATH_RE.search(spec))
             if skipping:
-                redacted.append(spec)
+                redacted.append(current_path or spec)
                 out_lines.append(line)  # keep the real header so reviewers see the file
                 out_lines.append("[redacted: secret-looking file not sent]")
                 continue
         if not skipping:
+            scan_line = (
+                (line.startswith(("+", "-", " ")) and
+                 not line.startswith(("+++", "---"))) or
+                line.startswith("Authorization:")
+            )
+            if scan_line:
+                line, changed = _redact_secret_values(line)
+                if changed and current_path and current_path not in redacted:
+                    redacted.append(current_path)
             out_lines.append(line)
     return "\n".join(out_lines), redacted
 

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/jobs.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/jobs.py
@@ -175,6 +175,7 @@ class JobConfig:
     workspace_source: Optional[str]
     context_summary: Optional[ContextSummary]
     requested_max_budget_usd: Optional[float] = None
+    redacted_paths: Optional[list[str]] = None
 
 
 def start_job(cmd: list[str], cwd: str, cfg: JobConfig) -> tuple[str, str]:
@@ -209,6 +210,7 @@ def start_job(cmd: list[str], cwd: str, cfg: JobConfig) -> tuple[str, str]:
             "timeout_seconds": cfg.timeout_seconds,
             "workspace_source": cfg.workspace_source, "cwd": cwd,
             "requested_max_budget_usd": cfg.requested_max_budget_usd,
+            "redacted_paths": cfg.redacted_paths or [],
         },
         "context_summary": summary,
     }
@@ -319,6 +321,7 @@ def _build_meta(meta: dict, status: str) -> Meta:
         scope=c.get("scope"), base=c.get("base"),
         timeout_seconds=c.get("timeout_seconds", max_seconds()),
         requested_max_budget_usd=c.get("requested_max_budget_usd"),
+        redacted_paths=c.get("redacted_paths") or [],
         elapsed_ms=_elapsed_ms(meta),
         job_id=meta.get("job_id"),
     )

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/normalize.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/normalize.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import re
 from typing import Any, Optional
 
 from cc_plugin_codex.schemas import (
@@ -65,18 +64,37 @@ def build_prompt(tool: str, payload: dict[str, Any], context_text: str) -> str:
 
 
 def extract_json(text: str) -> Optional[dict]:
-    fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
-    candidate = fenced.group(1) if fenced else None
-    if candidate is None:
-        brace = re.search(r"\{.*\}", text, re.DOTALL)
-        candidate = brace.group(0) if brace else None
-    if candidate is None:
+    decoder = json.JSONDecoder()
+
+    def scan(candidate: str) -> Optional[dict]:
+        for idx, char in enumerate(candidate):
+            if char != "{":
+                continue
+            try:
+                parsed, _ = decoder.raw_decode(candidate[idx:])
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                return parsed
         return None
-    try:
-        parsed = json.loads(candidate)
-        return parsed if isinstance(parsed, dict) else None
-    except json.JSONDecodeError:
-        return None
+
+    fence_start = 0
+    while True:
+        start = text.find("```", fence_start)
+        if start < 0:
+            break
+        body_start = text.find("\n", start + 3)
+        if body_start < 0:
+            break
+        end = text.find("```", body_start + 1)
+        if end < 0:
+            break
+        parsed = scan(text[body_start + 1:end])
+        if parsed is not None:
+            return parsed
+        fence_start = end + 3
+
+    return scan(text)
 
 
 def _clamp(value: Any, allowed: set[str], default: str) -> str:

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/schemas.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/schemas.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 # Bump this whenever the agent-visible surface changes: tool names, input or
 # output schemas, the ErrorCode set, the config_mode/access/scope/detail value
 # sets, or the capability guarantees in CAPABILITY_SUMMARY. Clients cache by it.
-FINGERPRINT = "cc-plugin-codex/0.1/schema-9"
+FINGERPRINT = "cc-plugin-codex/0.1/schema-10"
 
 Severity = Literal["critical", "high", "medium", "low", "nit"]
 Verdict = Literal["pass", "concerns", "fail", "unknown"]
@@ -103,6 +103,7 @@ class Meta(BaseModel):
     truncation_hint: Optional[str] = None
     command_exit_code: Optional[int] = None
     permission_denials: Optional[list] = None
+    redacted_paths: list[str] = Field(default_factory=list)
     cost_usd: Optional[float] = None
     usage: Optional[Usage] = None
     job_id: Optional[str] = None   # set on background-job results; None for sync calls
@@ -287,9 +288,9 @@ def _object_union_schema(adapter: TypeAdapter) -> dict:
 RESULT_SCHEMA = _object_union_schema(TypeAdapter(SuccessResult | ErrorResult))
 STATUS_SCHEMA = StatusResult.model_json_schema()
 CAPABILITIES_SCHEMA = CapabilitiesResult.model_json_schema()
-# A failed *_async launch (e.g. context_too_large) returns the error envelope, so
-# the start tools advertise the JobStarted|ErrorResult union.
-JOB_STARTED_SCHEMA = _object_union_schema(TypeAdapter(JobStarted | ErrorResult))
+# A failed *_async launch returns the error envelope; an empty diff returns a
+# SuccessResult without starting a job.
+JOB_STARTED_SCHEMA = _object_union_schema(TypeAdapter(JobStarted | SuccessResult | ErrorResult))
 JOB_STATUS_SCHEMA = _object_union_schema(TypeAdapter(JobStatus | ErrorResult))
 # Dry-run and job-list can fail (bad scope/base/workspace), so advertise the union.
 DRY_RUN_SCHEMA = _object_union_schema(TypeAdapter(DryRunResult | ErrorResult))

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
@@ -22,7 +22,7 @@ from cc_plugin_codex.claude import (
 from cc_plugin_codex.config import (
     MAX_BUDGET_USD, MAX_TIMEOUT_SECONDS, MIN_BUDGET_USD, MIN_TIMEOUT_SECONDS,
     VALID_EFFORTS, bare_available, clamp_budget, clamp_timeout, defaults,
-    sanitize_effort, version_supported,
+    max_input_bytes, sanitize_effort, version_supported,
 )
 from cc_plugin_codex.context import (
     MAX_DIFF_BYTES, InvalidBaseError, InvalidScopeError, gather_context,
@@ -34,8 +34,8 @@ from cc_plugin_codex.schemas import (
     CAPABILITIES_SCHEMA, DRY_RUN_SCHEMA, FINGERPRINT, JOB_LIST_SCHEMA,
     JOB_STARTED_SCHEMA, JOB_STATUS_SCHEMA, RESULT_SCHEMA, STATUS_SCHEMA,
     Access, CapabilitiesResult, ConfigMode, Detail, DryRunResult, Effort,
-    ErrorInfo, ErrorResult, JobStarted, Meta, ResolvedDefaults, Scope, StatusResult,
-    workspace_warning_for,
+    ErrorInfo, ErrorResult, JobStarted, Meta, RawResponse, ResolvedDefaults, Scope,
+    StatusResult, SuccessResult, workspace_warning_for,
 )
 
 CAPABILITY_SUMMARY = (
@@ -46,9 +46,10 @@ CAPABILITY_SUMMARY = (
     "claude_review_changes_async runs in background with poll/result/cancel; "
     "claude_review_dry_run previews workspace/diff-size/redaction for free. Findings "
     "are advisory claims to verify. Pass workspace_root explicitly: it defaults to "
-    "the first MCP root, else the server's own cwd (likely NOT your repo); when roots "
+    "the first MCP root, else the server cwd (likely NOT your repo); when roots "
     "exist it must be inside one. access=toolless is the default; access=readonly "
-    "lets Claude read files directly, bypassing filename-based secret redaction. "
+    "lets Claude read files directly, bypassing server-gathered diff redaction. "
+    "Free-form input is capped by CC_PLUGIN_CODEX_MAX_INPUT_BYTES. "
     "Experimental; pin fingerprint from cc_codex_capabilities."
 )
 
@@ -87,13 +88,15 @@ def _meta(cwd: str, config_mode: str, access: str, timeout: int, elapsed: int,
           exit_code: int | None, scope: str | None = None, base: str | None = None,
           truncated: bool = False, hint: str | None = None,
           workspace_source: str | None = None,
-          requested_budget: float | None = None) -> Meta:
+          requested_budget: float | None = None,
+          redacted_paths: list[str] | None = None) -> Meta:
     return Meta(cwd=cwd, config_mode=config_mode, access=access, scope=scope, base=base,
                 timeout_seconds=timeout, elapsed_ms=elapsed, command_exit_code=exit_code,
                 truncated=truncated, truncation_hint=hint, fingerprint=FINGERPRINT,
                 workspace_source=workspace_source,
                 workspace_warning=workspace_warning_for(workspace_source, cwd),
-                requested_max_budget_usd=requested_budget)
+                requested_max_budget_usd=requested_budget,
+                redacted_paths=redacted_paths or [])
 
 
 def _err(code: str, message: str, repair: str, meta: Meta,
@@ -190,6 +193,40 @@ async def _resolve_workspace(workspace_root, ctx):
     return path, None, source
 
 
+def _utf8_len(value: str | None) -> int:
+    return len((value or "").encode("utf-8", "replace"))
+
+
+def _validate_input_size(fields: dict[str, str | None], meta: Meta) -> dict | None:
+    limit = max_input_bytes()
+    total = sum(_utf8_len(value) for value in fields.values())
+    if total <= limit:
+        return None
+    largest = max(fields, key=lambda key: _utf8_len(fields[key]))
+    return _err(
+        "context_too_large",
+        f"User-supplied text is {total} bytes, exceeding the {limit}-byte limit.",
+        "Shorten the prompt/evidence/context, split the request, or raise "
+        "CC_PLUGIN_CODEX_MAX_INPUT_BYTES if this workspace intentionally allows it.",
+        meta,
+        offending=largest,
+    )
+
+
+def _empty_diff_result(tool: str, meta: Meta, context_summary,
+                       verdict: str = "pass", confidence: str = "high") -> dict:
+    result = SuccessResult(
+        tool=tool,
+        summary="No changes in scope; skipped Claude call.",
+        verdict=verdict,
+        confidence=confidence,
+        raw_response=RawResponse(),
+        context_summary=context_summary,
+        meta=meta,
+    )
+    return result.model_dump(mode="json", exclude_none=True)
+
+
 @dataclass
 class Resolved:
     config_mode: str
@@ -240,12 +277,13 @@ def _resolve(config_mode, access, model, max_budget_usd, timeout_seconds, detail
 
 async def _execute(tool, payload, r: Resolved, cwd,
                    scope=None, base=None, context_text="", context_summary=None,
-                   workspace_source=None) -> dict:
+                   workspace_source=None, redacted_paths: list[str] | None = None) -> dict:
     prompt = build_prompt(tool, payload, context_text)
     cmd = build_command(prompt, r.config_mode, r.access, r.model, r.budget, r.effort)
     run = await run_claude_async(cmd, cwd=cwd, timeout_seconds=r.timeout)
     meta = _meta(cwd, r.config_mode, r.access, r.timeout, run.elapsed_ms, run.exit_code,
-                 scope, base, workspace_source=workspace_source, requested_budget=r.budget)
+                 scope, base, workspace_source=workspace_source, requested_budget=r.budget,
+                 redacted_paths=redacted_paths)
     if run.exit_code != 0 or run.timed_out:
         # A non-zero exit can still carry a cost-bearing JSON envelope (e.g.
         # budget_exceeded); report what it spent when available.
@@ -287,8 +325,9 @@ async def claude_ask(
 
     Use when the task is a question or design choice, not a git diff review or
     adversarial attack. Paid external call; read-only; blocks up to
-    timeout_seconds and can be cancelled but not resumed. Returns structured
-    ok:true findings or ok:false repair errors.
+    timeout_seconds and can be cancelled but not resumed. Free-form input is
+    size-capped before spend. Returns structured ok:true findings or ok:false
+    repair errors.
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
@@ -298,6 +337,11 @@ async def claude_ask(
     if err:
         return _result(err)
     payload = {"prompt": prompt, "context": context}
+    meta = _meta(cwd, r.config_mode, r.access, r.timeout, 0, None,
+                 workspace_source=ws_source, requested_budget=r.budget)
+    too_large = _validate_input_size(payload, meta)
+    if too_large:
+        return _result(too_large)
     out = await _execute("claude_ask", payload, r, cwd, workspace_source=ws_source)
     return _result(out)
 
@@ -330,7 +374,7 @@ async def claude_review_changes(
     Use for correctness, regression, security, or test-coverage review of
     working_tree, staged, or branch diff. Paid external call; read-only; blocks up
     to timeout_seconds and can be cancelled but not resumed. For long reviews, use
-    claude_review_changes_async.
+    claude_review_changes_async. Empty diffs return ok:true without calling Claude.
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
@@ -359,13 +403,19 @@ async def claude_review_changes(
     if ctx_data.truncated:
         meta = _meta(cwd, r.config_mode, r.access, r.timeout, 0, None, scope, base,
                      truncated=True, hint=ctx_data.truncation_hint, workspace_source=ws_source,
-                     requested_budget=r.budget)
+                     requested_budget=r.budget, redacted_paths=ctx_data.redacted_paths)
         return _result(_err("context_too_large", "The diff is too large to review safely.",
                        ctx_data.truncation_hint or "Narrow the scope.", meta))
+    meta = _meta(cwd, r.config_mode, r.access, r.timeout, 0, None, scope, base,
+                 workspace_source=ws_source, requested_budget=r.budget,
+                 redacted_paths=ctx_data.redacted_paths)
+    if ctx_data.summary.files_changed == 0 and not ctx_data.text.strip():
+        return _result(_empty_diff_result("claude_review_changes", meta, ctx_data.summary))
     out = await _execute(
         "claude_review_changes", {"scope": scope, "base": base, "focus": focus},
         r, cwd, scope=scope, base=base, context_text=ctx_data.text,
-        context_summary=ctx_data.summary, workspace_source=ws_source)
+        context_summary=ctx_data.summary, workspace_source=ws_source,
+        redacted_paths=ctx_data.redacted_paths)
     return _result(out)
 
 
@@ -398,7 +448,9 @@ async def claude_adversarial_review(
 
     Use to surface counterarguments and failure modes. Include evidence text, and
     optionally attach a git diff with scope/base. Paid external call; read-only;
-    blocks up to timeout_seconds and can be cancelled but not resumed.
+    blocks up to timeout_seconds and can be cancelled but not resumed. Free-form
+    input is size-capped before spend; an empty attached diff returns ok:true
+    without calling Claude.
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
@@ -408,8 +460,15 @@ async def claude_adversarial_review(
                       effort=effort)
     if err:
         return _result(err)
+    payload = {"target": target, "evidence": evidence}
+    meta = _meta(cwd, r.config_mode, r.access, r.timeout, 0, None, scope, base,
+                 workspace_source=ws_source, requested_budget=r.budget)
+    too_large = _validate_input_size(payload, meta)
+    if too_large:
+        return _result(too_large)
     context_text = ""
     context_summary = None
+    redacted_paths: list[str] = []
     if scope:
         meta = _meta(cwd, r.config_mode, r.access, r.timeout, 0, None, scope, base,
                      workspace_source=ws_source)
@@ -430,15 +489,25 @@ async def claude_adversarial_review(
         if ctx_data.truncated:
             meta = _meta(cwd, r.config_mode, r.access, r.timeout, 0, None, scope, base,
                          truncated=True, hint=ctx_data.truncation_hint,
-                         workspace_source=ws_source)
+                         workspace_source=ws_source, requested_budget=r.budget,
+                         redacted_paths=ctx_data.redacted_paths)
             return _result(_err("context_too_large",
                            "The attached diff is too large to review safely.",
                            ctx_data.truncation_hint or "Narrow the scope.", meta))
+        meta = _meta(cwd, r.config_mode, r.access, r.timeout, 0, None, scope, base,
+                     workspace_source=ws_source, requested_budget=r.budget,
+                     redacted_paths=ctx_data.redacted_paths)
+        if ctx_data.summary.files_changed == 0 and not ctx_data.text.strip():
+            return _result(_empty_diff_result("claude_adversarial_review", meta,
+                                              ctx_data.summary, verdict="unknown",
+                                              confidence="low"))
         context_text, context_summary = ctx_data.text, ctx_data.summary
+        redacted_paths = ctx_data.redacted_paths
     out = await _execute(
-        "claude_adversarial_review", {"target": target, "evidence": evidence},
+        "claude_adversarial_review", payload,
         r, cwd, scope=scope, base=base, context_text=context_text,
-        context_summary=context_summary, workspace_source=ws_source)
+        context_summary=context_summary, workspace_source=ws_source,
+        redacted_paths=redacted_paths)
     return _result(out)
 
 
@@ -476,7 +545,8 @@ async def claude_review_changes_async(
     Use when a diff review may outlive the current turn. Paid external call;
     creates local job state and cannot be resumed if cancelled. Poll with
     claude_job_status, read with claude_job_result, delete after reading with
-    claude_job_consume_result, or stop with claude_job_cancel.
+    claude_job_consume_result, or stop with claude_job_cancel. Empty diffs return
+    ok:true immediately without starting a job.
     """
     cwd, ws_err, ws_source = await _resolve_workspace(workspace_root, ctx)
     if ws_err:
@@ -507,16 +577,22 @@ async def claude_review_changes_async(
     if ctx_data.truncated:
         meta = _meta(cwd, r.config_mode, r.access, job_timeout, 0, None, scope, base,
                      truncated=True, hint=ctx_data.truncation_hint, workspace_source=ws_source,
-                     requested_budget=r.budget)
+                     requested_budget=r.budget, redacted_paths=ctx_data.redacted_paths)
         return _result(_err("context_too_large", "The diff is too large to review safely.",
                        ctx_data.truncation_hint or "Narrow the scope.", meta))
+    meta = _meta(cwd, r.config_mode, r.access, job_timeout, 0, None, scope, base,
+                 workspace_source=ws_source, requested_budget=r.budget,
+                 redacted_paths=ctx_data.redacted_paths)
+    if ctx_data.summary.files_changed == 0 and not ctx_data.text.strip():
+        return _result(_empty_diff_result("claude_review_changes", meta, ctx_data.summary))
     prompt = build_prompt("claude_review_changes",
                           {"scope": scope, "base": base, "focus": focus}, ctx_data.text)
     cmd = build_command(prompt, r.config_mode, r.access, r.model, r.budget, r.effort)
     cfg = JobConfig(kind="claude_review_changes", config_mode=r.config_mode,
                     access=r.access, scope=scope, base=base, detail=r.detail,
                     timeout_seconds=jobs.max_seconds(), workspace_source=ws_source,
-                    context_summary=ctx_data.summary, requested_max_budget_usd=r.budget)
+                    context_summary=ctx_data.summary, requested_max_budget_usd=r.budget,
+                    redacted_paths=ctx_data.redacted_paths)
     job_id, started_at = await anyio.to_thread.run_sync(
         lambda: jobs.start_job(cmd, cwd, cfg))
     started = JobStarted(
@@ -525,7 +601,8 @@ async def claude_review_changes_async(
         poll_after_ms=jobs.poll_after_ms(),
         ttl_seconds=jobs.ttl_seconds(),
         meta=_meta(cwd, r.config_mode, r.access, job_timeout, 0, None, scope, base,
-                   workspace_source=ws_source, requested_budget=r.budget),
+                   workspace_source=ws_source, requested_budget=r.budget,
+                   redacted_paths=ctx_data.redacted_paths),
     )
     return _result(started.model_dump(mode="json", exclude_none=True))
 
@@ -783,8 +860,8 @@ def _capabilities_payload() -> dict:
             "does NOT act as a general Claude chat",
             "does NOT proxy Claude's own MCP tools",
             "does NOT resume a call once it ends or is cancelled",
-            "does NOT content-scan for secrets; with access=readonly Claude can read "
-            "workspace files directly, bypassing filename-based redaction",
+            "does NOT guarantee secret removal; diff redaction is best-effort and "
+            "access=readonly lets Claude read workspace files directly",
         ],
         prerequisites=[
             "the `claude` CLI installed and authenticated",

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
@@ -471,7 +471,7 @@ async def claude_adversarial_review(
     redacted_paths: list[str] = []
     if scope:
         meta = _meta(cwd, r.config_mode, r.access, r.timeout, 0, None, scope, base,
-                     workspace_source=ws_source)
+                     workspace_source=ws_source, requested_budget=r.budget)
         try:
             ctx_data = await anyio.to_thread.run_sync(
                 lambda: gather_context(cwd, scope=scope, base=base))

--- a/plugins/cc-plugin-codex/tests/test_claude.py
+++ b/plugins/cc-plugin-codex/tests/test_claude.py
@@ -112,6 +112,30 @@ def test_classify_budget_from_envelope_subtype():
     assert classify_failure(run).code == "budget_exceeded"
 
 
+def test_classify_auth_from_structured_envelope():
+    import json
+    stdout = json.dumps({"type": "result", "is_error": True,
+                         "subtype": "auth_required", "result": "please login"})
+    run = ClaudeRun(stdout=stdout, stderr="unrelated", exit_code=1,
+                    elapsed_ms=5, timed_out=False)
+    assert classify_failure(run).code == "claude_auth_required"
+
+
+def test_classify_permission_from_structured_envelope():
+    import json
+    stdout = json.dumps({"type": "result", "is_error": True,
+                         "subtype": "permission_denied", "result": "Read denied"})
+    run = ClaudeRun(stdout=stdout, stderr="", exit_code=1, elapsed_ms=5,
+                    timed_out=False)
+    assert classify_failure(run).code == "claude_permission_error"
+
+
+def test_classify_malformed_structured_error_falls_back():
+    run = ClaudeRun(stdout='{"is_error": true,', stderr="something else",
+                    exit_code=2, elapsed_ms=5, timed_out=False)
+    assert classify_failure(run).code == "nonzero_exit"
+
+
 def test_build_command_separates_prompt_with_double_dash():
     cmd = build_command(prompt="--model evil", config_mode="inherit", access="toolless",
                         model=None, max_budget_usd=1.0)

--- a/plugins/cc-plugin-codex/tests/test_context.py
+++ b/plugins/cc-plugin-codex/tests/test_context.py
@@ -41,6 +41,73 @@ def test_secret_files_redacted(git_repo):
     res = gather_context(str(git_repo), scope="working_tree", base="main")
     assert "supersecret" not in res.text
     assert ".env" in res.text  # path noted as redacted
+    assert ".env" in res.redacted_paths
+
+
+def test_secret_values_in_source_are_redacted(git_repo):
+    (git_repo / "app.py").write_text(
+        "def add(a, b):\n"
+        "    token = 'ghp_1234567890abcdefghijklmnopqrstu'\n"
+        "    return a - b\n"
+    )
+    res = gather_context(str(git_repo), scope="working_tree", base="main")
+    assert "ghp_1234567890abcdefghijklmnopqrstu" not in res.text
+    assert "[redacted: secret value]" in res.text
+    assert "app.py" in res.redacted_paths
+
+
+def test_secret_values_in_removed_lines_are_redacted(git_repo):
+    subprocess.run(["git", "checkout", "--", "app.py"], cwd=git_repo, check=True)
+    (git_repo / "app.py").write_text(
+        "def add(a, b):\n"
+        "    token = 'ghp_1234567890abcdefghijklmnopqrstu'\n"
+        "    return a + b\n"
+    )
+    subprocess.run(["git", "add", "app.py"], cwd=git_repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "add token"], cwd=git_repo, check=True)
+    (git_repo / "app.py").write_text("def add(a, b):\n    return a + b\n")
+    res = gather_context(str(git_repo), scope="working_tree", base="main")
+    assert "ghp_1234567890abcdefghijklmnopqrstu" not in res.text
+    assert "[redacted: secret value]" in res.text
+
+
+def test_secret_values_in_context_lines_are_redacted(git_repo):
+    subprocess.run(["git", "checkout", "--", "app.py"], cwd=git_repo, check=True)
+    (git_repo / "app.py").write_text(
+        "def add(a, b):\n"
+        "    token = 'ghp_1234567890abcdefghijklmnopqrstu'\n"
+        "    return a + b\n"
+    )
+    subprocess.run(["git", "add", "app.py"], cwd=git_repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "add token"], cwd=git_repo, check=True)
+    (git_repo / "app.py").write_text(
+        "def add(a, b):\n"
+        "    token = 'ghp_1234567890abcdefghijklmnopqrstu'\n"
+        "    return a - b\n"
+    )
+    res = gather_context(str(git_repo), scope="working_tree", base="main")
+    assert "ghp_1234567890abcdefghijklmnopqrstu" not in res.text
+    assert "[redacted: secret value]" in res.text
+
+
+def test_redacted_paths_are_normalized(git_repo):
+    (git_repo / ".env").write_text("API_KEY=supersecret\n")
+    subprocess.run(["git", "add", "-Nf", ".env"], cwd=git_repo, check=True)
+    res = gather_context(str(git_repo), scope="working_tree", base="main")
+    assert ".env" in res.redacted_paths
+    assert all(" b/" not in path for path in res.redacted_paths)
+
+
+def test_git_timeout_is_bounded(monkeypatch, git_repo):
+    import cc_plugin_codex.context as ctx
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+    monkeypatch.setenv("CC_PLUGIN_CODEX_GIT_TIMEOUT_SECONDS", "2")
+    monkeypatch.setattr(ctx.subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="timed out after 2s"):
+        gather_context(str(git_repo), scope="working_tree", base="main")
 
 
 def test_size_cap_truncates(git_repo, monkeypatch):

--- a/plugins/cc-plugin-codex/tests/test_normalize.py
+++ b/plugins/cc-plugin-codex/tests/test_normalize.py
@@ -34,6 +34,21 @@ def test_extract_json_plain_object():
     assert extract_json('{"verdict": "fail"}') == {"verdict": "fail"}
 
 
+def test_extract_json_ignores_prose_braces_before_object():
+    text = 'Use {placeholder} in prose, then {"verdict": "pass", "summary": "ok"}.'
+    assert extract_json(text) == {"verdict": "pass", "summary": "ok"}
+
+
+def test_extract_json_handles_braces_inside_strings():
+    text = '```json\n{"summary": "literal { brace }", "verdict": "pass"}\n```'
+    assert extract_json(text) == {"summary": "literal { brace }", "verdict": "pass"}
+
+
+def test_extract_json_uses_first_valid_object():
+    text = 'bad {not json} good {"verdict": "concerns"} {"verdict": "pass"}'
+    assert extract_json(text) == {"verdict": "concerns"}
+
+
 def test_extract_json_none_when_absent():
     assert extract_json("no json here") is None
 

--- a/plugins/cc-plugin-codex/tests/test_schemas.py
+++ b/plugins/cc-plugin-codex/tests/test_schemas.py
@@ -21,6 +21,12 @@ def test_meta_carries_cost_and_usage_fields():
     assert dumped["usage"]["input_tokens"] == 3
 
 
+def test_meta_carries_redacted_paths():
+    m = Meta(cwd="/x", config_mode="inherit", access="toolless",
+             timeout_seconds=10, elapsed_ms=1, redacted_paths=["app.py"])
+    assert m.model_dump(mode="json", exclude_none=True)["redacted_paths"] == ["app.py"]
+
+
 def test_finding_supports_line_range():
     from cc_plugin_codex.schemas import Finding
     f = Finding(severity="low", title="t", evidence="e", risk="r",
@@ -38,7 +44,7 @@ def test_success_result_has_next_steps():
 
 
 def test_fingerprint_value():
-    assert FINGERPRINT == "cc-plugin-codex/0.1/schema-9"
+    assert FINGERPRINT == "cc-plugin-codex/0.1/schema-10"
 
 
 def test_success_result_dump_omits_none():

--- a/plugins/cc-plugin-codex/tests/test_server.py
+++ b/plugins/cc-plugin-codex/tests/test_server.py
@@ -199,7 +199,45 @@ async def test_claude_ask_returns_normalized(fake_claude):
     data = structured(result)
     assert data["ok"] is True
     assert data["verdict"] == "concerns"
-    assert data["meta"]["fingerprint"] == "cc-plugin-codex/0.1/schema-9"
+    assert data["meta"]["fingerprint"] == "cc-plugin-codex/0.1/schema-10"
+
+
+async def test_claude_ask_rejects_oversized_prompt_before_paid_call(monkeypatch, tmp_path):
+    import cc_plugin_codex.server as srv
+
+    async def fail_run(*args, **kwargs):
+        raise AssertionError("paid call should not run")
+
+    monkeypatch.setenv("CC_PLUGIN_CODEX_MAX_INPUT_BYTES", "1000")
+    monkeypatch.setattr(srv, "run_claude_async", fail_run)
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "claude_ask",
+            {"prompt": "x" * 1500, "workspace_root": str(tmp_path)},
+            raise_on_error=False)
+    data = structured(result)
+    assert data["ok"] is False
+    assert data["error"]["code"] == "context_too_large"
+    assert data["error"]["offending_param"] == "prompt"
+
+
+async def test_adversarial_rejects_oversized_evidence_before_paid_call(monkeypatch, tmp_path):
+    import cc_plugin_codex.server as srv
+
+    async def fail_run(*args, **kwargs):
+        raise AssertionError("paid call should not run")
+
+    monkeypatch.setenv("CC_PLUGIN_CODEX_MAX_INPUT_BYTES", "1000")
+    monkeypatch.setattr(srv, "run_claude_async", fail_run)
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "claude_adversarial_review",
+            {"target": "x", "evidence": "y" * 1500, "workspace_root": str(tmp_path)},
+            raise_on_error=False)
+    data = structured(result)
+    assert data["ok"] is False
+    assert data["error"]["code"] == "context_too_large"
+    assert data["error"]["offending_param"] == "evidence"
 
 
 async def test_invalid_enum_param_rejected_by_schema(fake_claude):
@@ -332,6 +370,56 @@ async def test_review_changes_runs_in_git_repo(fake_claude, monkeypatch, git_rep
     data = structured(result)
     assert data["ok"] is True
     assert data["verdict"] == "concerns"
+
+
+async def test_review_changes_empty_diff_skips_paid_call(monkeypatch, git_repo):
+    import subprocess as _sp
+    import cc_plugin_codex.server as srv
+
+    _sp.run(["git", "checkout", "--", "app.py"], cwd=git_repo, check=True)
+
+    async def fail_run(*args, **kwargs):
+        raise AssertionError("paid call should not run")
+
+    monkeypatch.setattr(srv, "run_claude_async", fail_run)
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "claude_review_changes",
+            {"scope": "working_tree", "workspace_root": str(git_repo)})
+    data = structured(result)
+    assert data["ok"] is True
+    assert data["verdict"] == "pass"
+    assert "No changes" in data["summary"]
+    assert data["context_summary"]["files_changed"] == 0
+
+
+async def test_adversarial_empty_attached_diff_skips_paid_call(monkeypatch, git_repo):
+    import subprocess as _sp
+    import cc_plugin_codex.server as srv
+
+    _sp.run(["git", "checkout", "--", "app.py"], cwd=git_repo, check=True)
+
+    async def fail_run(*args, **kwargs):
+        raise AssertionError("paid call should not run")
+
+    monkeypatch.setattr(srv, "run_claude_async", fail_run)
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "claude_adversarial_review",
+            {"target": "review plan", "scope": "working_tree",
+             "workspace_root": str(git_repo)})
+    data = structured(result)
+    assert data["ok"] is True
+    assert data["verdict"] == "unknown"
+    assert data["context_summary"]["files_changed"] == 0
+
+
+async def test_adversarial_without_scope_still_calls_claude(fake_claude, tmp_path):
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "claude_adversarial_review",
+            {"target": "review plan", "workspace_root": str(tmp_path)})
+    assert structured(result)["ok"] is True
 
 
 async def test_adversarial_invalid_scope_param_rejected_by_schema(fake_claude, monkeypatch, git_repo):
@@ -554,7 +642,7 @@ async def test_capabilities_tool_returns_structured_contract():
     async with Client(mcp) as client:
         result = await client.call_tool("cc_codex_capabilities", {})
     data = structured(result)
-    assert data["fingerprint"] == "cc-plugin-codex/0.1/schema-9"
+    assert data["fingerprint"] == "cc-plugin-codex/0.1/schema-10"
     assert data["transport"] == "stdio"
     assert set(data["paid_tools"]) == {
         "claude_ask", "claude_review_changes", "claude_adversarial_review",
@@ -613,6 +701,73 @@ async def test_dry_run_reports_redaction_count(monkeypatch, git_repo):
             {"scope": "working_tree", "workspace_root": str(git_repo)}))
     assert data["redacted_paths_count"] >= 1
     assert any(".env" in p for p in data["redacted_paths"])
+
+
+async def test_review_result_reports_redacted_paths(fake_claude, git_repo):
+    import subprocess as _sp
+
+    (git_repo / ".env").write_text("API_KEY=supersecret\n")
+    _sp.run(["git", "add", "-Nf", ".env"], cwd=git_repo, check=True)
+    async with Client(mcp) as client:
+        data = structured(await client.call_tool(
+            "claude_review_changes",
+            {"scope": "working_tree", "workspace_root": str(git_repo)}))
+    assert data["ok"] is True
+    assert any(".env" in p for p in data["meta"]["redacted_paths"])
+
+
+async def test_async_empty_diff_skips_job_start(monkeypatch, git_repo, tmp_path):
+    import subprocess as _sp
+    import cc_plugin_codex.server as srv
+
+    _sp.run(["git", "checkout", "--", "app.py"], cwd=git_repo, check=True)
+    monkeypatch.setenv("CC_PLUGIN_CODEX_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setattr(srv, "build_command",
+                        lambda *args, **kwargs: (_ for _ in ()).throw(
+                            AssertionError("job should not start")))
+    async with Client(mcp) as client:
+        data = structured(await client.call_tool(
+            "claude_review_changes_async",
+            {"scope": "working_tree", "workspace_root": str(git_repo)}))
+    assert data["ok"] is True
+    assert data["tool"] == "claude_review_changes"
+    assert data["verdict"] == "pass"
+
+
+async def test_async_result_reports_redacted_paths(monkeypatch, git_repo, tmp_path):
+    import json as _json
+    import subprocess as _sp
+    import time as _time
+
+    import cc_plugin_codex.server as srv
+
+    (git_repo / ".env").write_text("API_KEY=supersecret\n")
+    _sp.run(["git", "add", "-Nf", ".env"], cwd=git_repo, check=True)
+    monkeypatch.setenv("CC_PLUGIN_CODEX_STATE_DIR", str(tmp_path / "state"))
+    inner = {"summary": "ok", "verdict": "pass", "confidence": "high",
+             "findings": [], "questions": [], "assumptions": []}
+    envelope = _json.dumps({"type": "result", "subtype": "success", "is_error": False,
+                            "result": _json.dumps(inner)})
+    monkeypatch.setattr(srv, "build_command",
+                        lambda *a, **k: ["sh", "-c", "printf '%s' \"$0\"", envelope])
+
+    async with Client(mcp) as client:
+        started = structured(await client.call_tool(
+            "claude_review_changes_async",
+            {"scope": "working_tree", "workspace_root": str(git_repo)}))
+        job_id = started["job_id"]
+        deadline = _time.time() + 5
+        while _time.time() < deadline:
+            st = structured(await client.call_tool(
+                "claude_job_status",
+                {"job_id": job_id, "workspace_root": str(git_repo)}))
+            if st["status"] == "done":
+                break
+            await anyio.sleep(0.05)
+        result = structured(await client.call_tool(
+            "claude_job_result",
+            {"job_id": job_id, "workspace_root": str(git_repo)}))
+    assert ".env" in result["meta"]["redacted_paths"]
 
 
 async def test_dry_run_bad_base_is_structured_error(git_repo):


### PR DESCRIPTION
## Summary
- Bound free-form paid inputs and git context collection before spawning Claude
- Skip paid review/job startup for empty diffs and surface redacted paths in result metadata
- Add best-effort content secret redaction, robust JSON extraction, and structured Claude failure classification
- Add plugin-scoped ruff/pytest CI plus docs and schema fingerprint updates

## Verification
- prek hooks on commit: ruff check and pytest passed for plugins/cc-plugin-codex
- uv run ruff check src tests
- uv run pytest -q
- git diff --check

Closes #8
Closes #9
Closes #10
Closes #11
Closes #12
Closes #13
Closes #14
Closes #16