### PR TITLE
feat(cc-plugin-codex): harden against claude/Codex CLI breaking changes

### DIFF
--- a/plugins/cc-plugin-codex/.codex-plugin/plugin.json
+++ b/plugins/cc-plugin-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-plugin-codex",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Call Claude Code from Codex for bounded, independent code review and second opinions",
   "author": { "name": "Brian Connelly", "url": "https://github.com/briandconnelly" },
   "repository": "https://github.com/briandconnelly/cc-plugin-codex",

--- a/plugins/cc-plugin-codex/.mcp.json
+++ b/plugins/cc-plugin-codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/briandconnelly/briandconnelly-plugins.git#subdirectory=plugins/cc-plugin-codex",
+        "git+https://github.com/briandconnelly/briandconnelly-plugins.git@cc-plugin-codex-v0.1.3#subdirectory=plugins/cc-plugin-codex",
         "cc-plugin-codex-mcp"
       ]
     }

--- a/plugins/cc-plugin-codex/COMPATIBILITY.md
+++ b/plugins/cc-plugin-codex/COMPATIBILITY.md
@@ -1,0 +1,88 @@
+# Compatibility
+
+`cc-plugin-codex` is an MCP server that the Codex CLI loads and that shells out to
+the Claude Code `claude` CLI.
+It therefore depends on two fast-moving upstreams: the `claude` binary (the
+delegate it drives) and the Codex host (which loads it).
+This document maps every external assumption to where it lives in the code, how a
+break is detected, and what to change when it breaks.
+
+Every `claude`-side assumption is centralized in
+[`src/cc_plugin_codex/cli_contract.py`](./src/cc_plugin_codex/cli_contract.py).
+Changing an assumption should be a one-file edit there.
+
+## How the plugin degrades
+
+The design goal is to **fail loudly and safely**, never silently weaken a
+guarantee:
+
+- **Guarantee-bearing flags are always sent** (`cli_contract.ALWAYS_SEND_FLAGS`).
+  If `claude` removes or renames one, it rejects the invocation at argument
+  parsing — *before any model call, so zero spend* — and the failure is reported
+  as `cli_contract_changed` with repair guidance.
+  These flags carry a security, cost, or behavioral guarantee, so they are **never**
+  gated on `--help` parsing (a parsing false-negative must never drop one).
+- **Depth/cosmetic flags are feature-detected** (`cli_contract.HELP_GATED_FLAGS`).
+  They are dropped (and noted in `meta.compat_warnings`) when the installed
+  `claude --help` does not list them, so a minor upstream change degrades instead
+  of aborting a paid run.
+- **Version is advisory.** A `claude` major outside the tested range warns
+  (`claude_status.version_warning`) but does not block; `ready` depends only on the
+  CLI being found and authenticated.
+
+## `claude` CLI assumptions
+
+| Assumption | Code (cli_contract constant) | How a break is detected | If it breaks |
+| --- | --- | --- | --- |
+| Binary on PATH | `CLAUDE_BIN` | `claude_status.claude_found = false` | install Claude Code |
+| `-p --output-format json` (core) | `CORE_INVOCATION` | every call errors → `cli_contract_changed`; golden-envelope test | update `CORE_INVOCATION` + `normalize.py` |
+| `--no-chrome` (no interactive picker) ⚠️ | `ALWAYS_SEND_FLAGS` | `cli_contract_changed` at run time | update the constant |
+| `--append-system-prompt` (critic guardrails) ⚠️ | `ALWAYS_SEND_FLAGS` | `cli_contract_changed` | update the constant; the prompt is `config.INDEPENDENT_CRITIC_PROMPT` |
+| `--max-budget-usd` (spend cap) ⚠️ | `ALWAYS_SEND_FLAGS` | `cli_contract_changed` | update the constant |
+| `--tools` (read-only / no-tool guarantee) ⚠️ | `ALWAYS_SEND_FLAGS` | `cli_contract_changed` | update the constant in `config.access_flags` |
+| `--strict-mcp-config` / `--mcp-config` (drop user MCP fleet) ⚠️ | `ALWAYS_SEND_FLAGS` | `cli_contract_changed` | update `config.config_mode_flags` |
+| `--setting-sources` / `--bare` (mode isolation) ⚠️ | `ALWAYS_SEND_FLAGS` | `cli_contract_changed` | update `config.config_mode_flags` |
+| `--effort` + accepted levels | `HELP_GATED_FLAGS`, `VALID_EFFORTS` | dropped with `compat_warnings`; a removed *level* → `cli_contract_changed` | update `VALID_EFFORTS` |
+| `--model`, `--disallowed-tools`, `--no-session-persistence` | `HELP_GATED_FLAGS` | dropped with `compat_warnings` | update the constant |
+| JSON envelope keys (`is_error`, `subtype`, `result`, `total_cost_usd`, `usage.*`, `session_id`, `modelUsage`, `permission_denials`) | `ENVELOPE_KEYS`, `USAGE_KEYS`, `SUCCESS_SUBTYPES` | golden-envelope test (`tests/test_golden_envelope.py`); cost silently null if renamed | update `normalize.py` + the golden sample |
+| `claude --version` format (`MAJOR.MINOR.PATCH`) | `VERSION_ARGS`, `SUPPORTED_MAJORS` | `claude_status.version_supported = null` | adjust the regex in `config.version_supported` |
+| `claude auth status --text` exit code | `AUTH_STATUS_ARGS` | `claude_status.claude_authenticated = null` | update `claude.auth_status` |
+| `claude --help` lists long flags | `HELP_ARGS` | preflight fails open (everything assumed supported) | update `preflight._parse_supported` |
+
+⚠️ = **security/cost/behavioral guarantee.** Losing one of these would weaken
+read-only access, the no-MCP boundary, the spend cap, or the critic behavior — so
+the plugin refuses to run (fails closed) rather than silently proceed.
+
+**Residual risk:** if upstream *accepts but silently no-ops* a guarantee-bearing
+flag (rather than rejecting it), the loss cannot be detected without behavioral
+testing. The drift detection only catches rejection.
+
+## Codex-host assumptions
+
+| Assumption | Where | Notes |
+| --- | --- | --- |
+| Plugin manifest (`mcpServers`, `skills`) | `.codex-plugin/plugin.json` | Codex marketplace schema |
+| MCP launch (`uvx --from git+…@tag`) | `.mcp.json` | pinned to a release tag (see below) |
+| Entry point `cc-plugin-codex-mcp` | `pyproject.toml [project.scripts]` | |
+| MCP roots as `file://` URIs | `server.py` `_file_roots` | already tolerant; falls back to server cwd |
+
+## Versioning & release (lockstep)
+
+The bundled `.mcp.json` pins the server to a **plugin-scoped release tag**
+(`cc-plugin-codex-vX.Y.Z`) instead of tracking the default branch, so a breaking
+change no longer auto-ships to installed users — they update deliberately. The
+trade-off is that fixes (including resilience fixes) only reach users on the next
+tagged release.
+
+When cutting a release, bump these **together**:
+
+1. `pyproject.toml` `version`
+2. `.codex-plugin/plugin.json` `version`
+3. `FINGERPRINT` in `src/cc_plugin_codex/schemas.py` — **only** when the
+   agent-visible surface changed (tool names, input/output schemas, the
+   `ErrorCode` set, the value enums, or the capability summary)
+4. the `@cc-plugin-codex-vX.Y.Z` ref in `.mcp.json`
+5. create and push the matching `cc-plugin-codex-vX.Y.Z` git tag
+
+The `.mcp.json` ref and the git tag must match, or a bundled install fails to
+resolve.

--- a/plugins/cc-plugin-codex/README.md
+++ b/plugins/cc-plugin-codex/README.md
@@ -154,7 +154,19 @@ unrecognized `CC_PLUGIN_CODEX_EFFORT` env value instead falls back to the defaul
 `CC_PLUGIN_CODEX_CLAUDE_CONFIG`, `CC_PLUGIN_CODEX_ACCESS`, `CC_PLUGIN_CODEX_MODEL`,
 `CC_PLUGIN_CODEX_EFFORT`, `CC_PLUGIN_CODEX_MAX_BUDGET_USD`,
 `CC_PLUGIN_CODEX_TIMEOUT_SECONDS`, `CC_PLUGIN_CODEX_MAX_INPUT_BYTES`,
-`CC_PLUGIN_CODEX_GIT_TIMEOUT_SECONDS`, `ANTHROPIC_API_KEY`.
+`CC_PLUGIN_CODEX_GIT_TIMEOUT_SECONDS`, `CC_PLUGIN_CODEX_SUPPORTED_MAJORS`,
+`ANTHROPIC_API_KEY`.
 
 Background jobs add: `CC_PLUGIN_CODEX_STATE_DIR`, `CC_PLUGIN_CODEX_JOB_MAX_SECONDS`,
 `CC_PLUGIN_CODEX_JOB_TTL`, `CC_PLUGIN_CODEX_JOB_MAX_COUNT`.
+
+## Compatibility
+
+This server couples to the external `claude` CLI (and the Codex host).
+Every assumption — flags, JSON-envelope keys, subcommands, accepted effort levels,
+supported version range — is centralized in `src/cc_plugin_codex/cli_contract.py`
+and documented in [COMPATIBILITY.md](./COMPATIBILITY.md), which also covers what
+breaks on an upstream change and how to fix it.
+When a guarantee-bearing flag or the CLI contract drifts, paid tools fail loudly
+with a `cli_contract_changed` error (no silent weakening, no spend) and
+`claude_status` surfaces a version or flag warning for free.

--- a/plugins/cc-plugin-codex/pyproject.toml
+++ b/plugins/cc-plugin-codex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cc-plugin-codex"
-version = "0.1.2"
+version = "0.1.3"
 description = "Call Claude Code from Codex for bounded, independent code review and second opinions"
 requires-python = ">=3.10"
 dependencies = [

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/claude.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/claude.py
@@ -11,9 +11,11 @@ from dataclasses import dataclass
 
 import anyio
 
+from cc_plugin_codex import cli_contract, preflight
 from cc_plugin_codex.config import (
     INDEPENDENT_CRITIC_PROMPT, access_flags, config_mode_flags,
 )
+from cc_plugin_codex.preflight import FlagSupport
 from cc_plugin_codex.schemas import ErrorInfo
 
 
@@ -26,22 +28,52 @@ class ClaudeRun:
     timed_out: bool
 
 
+def _gate_optional(tokens: list[str], fs: FlagSupport) -> tuple[list[str], list[str]]:
+    """Drop any HELP_GATED flag (and its value, if it takes one) the installed
+    `claude` does not advertise in --help. Returns (kept_tokens, dropped_flags).
+    ALWAYS_SEND flags are never in HELP_GATED_FLAGS, so they always survive."""
+    kept: list[str] = []
+    dropped: list[str] = []
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        takes_value = cli_contract.HELP_GATED_FLAGS.get(token)
+        if takes_value is not None and not preflight.is_supported(token, fs):
+            dropped.append(token)
+            i += 2 if takes_value else 1
+            continue
+        kept.append(token)
+        i += 1
+    return kept, dropped
+
+
 def build_command(prompt: str, config_mode: str, access: str, model: str | None,
-                  max_budget_usd: float, effort: str | None = None) -> list[str]:
+                  max_budget_usd: float, effort: str | None = None,
+                  flag_support: FlagSupport | None = None) -> tuple[list[str], list[str]]:
+    """Build the `claude` invocation. Returns (cmd, dropped_optional_flags).
+
+    Guarantee-bearing flags are sent unconditionally; HELP_GATED (depth/cosmetic)
+    flags are dropped when the installed CLI does not list them, so a minor
+    upstream change degrades instead of aborting a paid run. dropped_optional_flags
+    feeds Meta.compat_warnings."""
+    fs = flag_support if flag_support is not None else preflight.flag_support()
     # --no-chrome disables the "Claude in Chrome" integration, which could
     # otherwise open an interactive picker that hangs an unattended run until the
     # timeout (burning the whole timeout and the spend) instead of answering.
-    cmd = ["claude", "-p", "--output-format", "json", "--no-chrome"]
-    cmd += config_mode_flags(config_mode)
-    cmd += access_flags(access)
-    cmd += ["--append-system-prompt", INDEPENDENT_CRITIC_PROMPT]
-    cmd += ["--max-budget-usd", f"{max_budget_usd}"]
-    if effort:
-        cmd += ["--effort", effort]
+    tokens = [cli_contract.CLAUDE_BIN, *cli_contract.CORE_INVOCATION, "--no-chrome"]
+    tokens += config_mode_flags(config_mode)
+    tokens += access_flags(access)
+    tokens += ["--append-system-prompt", INDEPENDENT_CRITIC_PROMPT]
+    tokens += ["--max-budget-usd", f"{max_budget_usd}"]
+    if effort and effort in cli_contract.VALID_EFFORTS:
+        tokens += ["--effort", effort]
     if model:
-        cmd += ["--model", model]
-    cmd += ["--", prompt]  # end-of-options separator, then the prompt as positional
-    return cmd
+        tokens += ["--model", model]
+    cmd, dropped = _gate_optional(tokens, fs)
+    # Gate BEFORE appending the prompt so a prompt that contains "--effort" etc.
+    # can never be mistaken for a flag.
+    cmd += [cli_contract.END_OF_OPTIONS, prompt]
+    return cmd, dropped
 
 
 def auth_status(timeout_seconds: int = 10) -> tuple[bool | None, str | None]:
@@ -54,7 +86,7 @@ def auth_status(timeout_seconds: int = 10) -> tuple[bool | None, str | None]:
     into shared logs/transcripts. The boolean already carries the machine-readable
     truth, so we deliberately drop the raw text."""
     try:
-        proc = subprocess.run(["claude", "auth", "status", "--text"],
+        proc = subprocess.run([cli_contract.CLAUDE_BIN, *cli_contract.AUTH_STATUS_ARGS],
                               capture_output=True, text=True, timeout=timeout_seconds)
     except (OSError, subprocess.SubprocessError):
         return None, None
@@ -181,6 +213,23 @@ def classify_failure(run: ClaudeRun) -> ErrorInfo:
                                  "(a best-effort limit, not a hard cap).",
                          repair="Raise max_budget_usd or reduce context.",
                          retryable=True)
+    # An unknown flag / invalid value means the CLI contract drifted from what this
+    # plugin sends. Check last so an auth/budget message is never misread as drift.
+    if cli_contract.is_contract_drift(run.stderr, run.stdout):
+        return contract_changed_error()
     return ErrorInfo(code="nonzero_exit",
                      message=f"claude exited {run.exit_code}: {run.stderr.strip()[:200]}",
                      repair="Inspect the error; retry with a smaller request.")
+
+
+def contract_changed_error() -> ErrorInfo:
+    """Shared cli_contract_changed error, reused across every failure path so a
+    drift is reported identically whether it surfaces on the sync, envelope, or
+    async-job path."""
+    return ErrorInfo(
+        code="cli_contract_changed",
+        message="claude rejected a flag or value this plugin sent — its CLI "
+                "contract likely changed for your installed version.",
+        repair="Update cc-plugin-codex (or pin claude to a supported version); "
+               "run claude_status to check the version.",
+    )

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/cli_contract.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/cli_contract.py
@@ -1,0 +1,107 @@
+"""Single source of truth for the external `claude` CLI contract.
+
+Every assumption this server makes about the `claude` CLI — its flags,
+subcommands, JSON-envelope keys, accepted effort levels, supported major
+versions, and the stderr phrasings that mean the contract drifted — lives here so
+an upstream breaking change is a one-file, greppable, testable edit. See
+COMPATIBILITY.md for the assumption -> upstream-source map.
+"""
+
+from __future__ import annotations
+
+CLAUDE_BIN = "claude"
+
+# Core invocation that CANNOT be dropped: -p (print mode) + JSON output. If these
+# disappear upstream the server cannot function, so a run must fail loudly rather
+# than silently degrade.
+CORE_INVOCATION = ("-p", "--output-format", "json")
+END_OF_OPTIONS = "--"
+
+# Subcommands / probes (free; no paid call).
+VERSION_ARGS = ("--version",)
+AUTH_STATUS_ARGS = ("auth", "status", "--text")
+HELP_ARGS = ("--help",)
+
+# --- Flag classes (see Item 5 of the resilience plan / COMPATIBILITY.md) --------
+# ALWAYS_SEND: guarantee-bearing flags, sent unconditionally and NEVER gated on
+# `--help` parsing. If upstream removes/renames one, `claude` rejects it at
+# arg-parse BEFORE any model call (zero spend) and classify_failure() labels it
+# cli_contract_changed. Gating these on the (inherently fuzzy) --help parse could
+# silently drop a security/cost/behavioral guarantee, so we never do. All are long
+# flags (the diagnostic in claude_status checks them against parsed --help).
+ALWAYS_SEND_FLAGS = frozenset({
+    "--output-format",                       # core JSON output
+    "--no-chrome",                           # no interactive picker hanging an unattended run
+    "--append-system-prompt",                # the independent-critic guardrails
+    "--max-budget-usd",                      # best-effort spend stop threshold
+    "--tools",                               # read-only / no-tool guarantee
+    "--strict-mcp-config", "--mcp-config",   # strip the user's MCP fleet (security boundary)
+    "--setting-sources",                     # scoped-mode isolation
+    "--bare",                                # bare-mode isolation
+})
+
+# HELP_GATED: dropping one only reduces depth or relies on a still-present primary
+# guard — never a safety/cost regression. The value is whether the flag takes an
+# argument (so the gate skips the value token too). These are the ONLY flags gated
+# on `claude --help`; a false negative here merely drops a harmless flag.
+HELP_GATED_FLAGS = {
+    "--effort": True,                    # reasoning depth only
+    "--model": True,                     # falls back to the configured default model
+    "--disallowed-tools": True,          # defense-in-depth; --tools is the primary allowlist
+    "--no-session-persistence": False,   # without it a session merely persists to disk
+}
+
+# Cache TTL for the `claude --help` probe, so a long-lived server re-probes after
+# an in-place CLI upgrade instead of trusting a stale snapshot forever.
+HELP_CACHE_TTL_SECONDS = 300
+
+# --- Reasoning effort -----------------------------------------------------------
+VALID_EFFORTS = ("low", "medium", "high", "xhigh", "max")
+DEFAULT_EFFORT = "xhigh"
+
+# --- Supported `claude` major version(s) ----------------------------------------
+# A set (not a single int) so a future major can be added without a code change,
+# and overridable via env so a user can opt into an untested major themselves.
+SUPPORTED_MAJORS = frozenset({2})
+SUPPORTED_MAJORS_ENV = "CC_PLUGIN_CODEX_SUPPORTED_MAJORS"
+
+# --- JSON envelope keys read from `claude -p --output-format json` ---------------
+# normalize.py / apply_cost_usage parse these tolerantly with .get(); listing them
+# here keeps the consumed surface greppable and gives the golden-envelope test a
+# canonical reference.
+SUCCESS_SUBTYPES = (None, "success")
+ENVELOPE_KEYS = frozenset({
+    "is_error", "subtype", "result", "total_cost_usd", "usage",
+    "session_id", "modelUsage", "permission_denials",
+})
+USAGE_KEYS = frozenset({
+    "input_tokens", "output_tokens",
+    "cache_read_input_tokens", "cache_creation_input_tokens",
+})
+
+# --- Contract-drift stderr signatures -------------------------------------------
+# Phrasings a CLI prints when it rejects a flag or value we sent. Matching any
+# (case-insensitive) reclassifies an otherwise-generic failure as
+# cli_contract_changed, telling the user the plugin needs an update for their CLI
+# rather than leaving a confusing nonzero_exit.
+CONTRACT_DRIFT_STDERR_PATTERNS = (
+    "unknown option",
+    "unknown flag",
+    "unknown argument",
+    "unrecognized option",
+    "unrecognized argument",
+    "no such option",
+    "invalid choice",
+    "invalid value",
+    "unexpected argument",
+)
+
+
+def is_contract_drift(*texts: str | None) -> bool:
+    """Whether any provided text carries a contract-drift signature.
+
+    Used on every failure path (sync classify_failure, the zero-exit is_error
+    envelope, and the async job error) so drift is labelled consistently no matter
+    where `claude` surfaces it."""
+    blob = "\n".join(t for t in texts if t).lower()
+    return any(pattern in blob for pattern in CONTRACT_DRIFT_STDERR_PATTERNS)

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/config.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/config.py
@@ -6,6 +6,11 @@ import os
 import re
 from dataclasses import dataclass
 
+from cc_plugin_codex import cli_contract
+# Re-exported so existing `from ...config import VALID_EFFORTS` callers keep
+# working; the canonical definition lives in cli_contract.
+from cc_plugin_codex.cli_contract import DEFAULT_EFFORT, VALID_EFFORTS
+
 EMPTY_MCP = '{"mcpServers":{}}'
 
 MIN_BUDGET_USD, MAX_BUDGET_USD = 0.01, 5.00
@@ -13,16 +18,7 @@ MIN_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS = 10, 600
 DEFAULT_MAX_INPUT_BYTES = 200_000
 DEFAULT_GIT_TIMEOUT_SECONDS = 60
 
-# Reasoning effort levels the `claude` CLI accepts for `--effort`. We default to
-# a high level because the whole value of this server is review depth; lower it
-# per-call (or via CC_PLUGIN_CODEX_EFFORT) to trade rigor for cost on routine work.
-VALID_EFFORTS = ("low", "medium", "high", "xhigh", "max")
-DEFAULT_EFFORT = "xhigh"
-
-# Major version of the `claude` CLI this server is built against. claude_status
-# reports whether the installed CLI matches, so a future breaking change in the
-# CLI contract is visible for free instead of only surfacing mid paid call.
-SUPPORTED_MAJOR = 2
+__all__ = ["VALID_EFFORTS", "DEFAULT_EFFORT"]  # re-exports; silence unused-import lints
 
 INDEPENDENT_CRITIC_PROMPT = (
     "You are being asked for an independent critique of Codex's work.\n"
@@ -89,17 +85,35 @@ def sanitize_effort(value: str | None) -> str:
     return value if value in VALID_EFFORTS else DEFAULT_EFFORT
 
 
+def supported_majors() -> frozenset[int]:
+    """The `claude` CLI major versions this server is built against.
+
+    Defaults to cli_contract.SUPPORTED_MAJORS; overridable via
+    CC_PLUGIN_CODEX_SUPPORTED_MAJORS (comma-separated ints) so a user can opt into
+    an untested major. Any parse error falls back to the built-in set rather than
+    raising."""
+    raw = os.environ.get(cli_contract.SUPPORTED_MAJORS_ENV)
+    if not raw:
+        return cli_contract.SUPPORTED_MAJORS
+    try:
+        parsed = frozenset(int(part) for part in raw.split(",") if part.strip())
+    except ValueError:
+        return cli_contract.SUPPORTED_MAJORS
+    return parsed or cli_contract.SUPPORTED_MAJORS
+
+
 def version_supported(version: str | None) -> bool | None:
-    """Whether the installed `claude --version` string matches SUPPORTED_MAJOR.
+    """Whether the installed `claude --version` major is in supported_majors().
 
     Returns None when the version is unknown/unparseable (so callers can report
-    'unknown' rather than a false 'unsupported')."""
+    'unknown' rather than a false 'unsupported'). Advisory only: claude_status
+    surfaces a mismatch as a warning and never blocks paid calls on it."""
     if not version:
         return None
     match = re.search(r"(\d+)\.\d+\.\d+", version)
     if not match:
         return None
-    return int(match.group(1)) == SUPPORTED_MAJOR
+    return int(match.group(1)) in supported_majors()
 
 
 def clamp_budget(value: float) -> float:

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/jobs.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/jobs.py
@@ -445,14 +445,25 @@ _STATE_TO_ERROR = {
 
 
 def _job_error(meta: dict, state: str, jd: Path) -> dict:
+    from cc_plugin_codex.cli_contract import is_contract_drift
     from cc_plugin_codex.schemas import ErrorInfo, ErrorResult
     if state == "failed":
-        code, message, repair = (
-            "job_failed",
-            f"The job failed without producing a result. {_stderr_tail(jd) or ''}".strip(),
-            "Run claude_status to check the CLI is installed and authenticated, then retry.",
-        )
-        retryable = True
+        tail = _stderr_tail(jd)
+        # A failed job whose stderr carries a drift signature is the async twin of
+        # the sync cli_contract_changed path — classify it the same way so async
+        # callers get the same actionable error instead of a generic job_failed.
+        if is_contract_drift(tail):
+            from cc_plugin_codex.claude import contract_changed_error
+            info = contract_changed_error()
+            code, message, repair, retryable = (
+                info.code, info.message, info.repair, info.retryable)
+        else:
+            code, message, repair = (
+                "job_failed",
+                f"The job failed without producing a result. {tail or ''}".strip(),
+                "Run claude_status to check the CLI is installed and authenticated, then retry.",
+            )
+            retryable = True
     else:
         code, message, repair = _STATE_TO_ERROR.get(
             state, ("job_failed", "The job did not complete.", "Start a new job."))

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/normalize.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/normalize.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from typing import Any, Optional
 
+from cc_plugin_codex import cli_contract
+from cc_plugin_codex.claude import contract_changed_error
 from cc_plugin_codex.schemas import (
     ContextSummary,
     ErrorInfo,
@@ -169,8 +171,12 @@ def normalize_envelope(
     # Plumb cost and usage onto meta regardless of success/error path.
     apply_cost_usage(meta, env)
 
-    if env.get("is_error") or env.get("subtype") not in (None, "success"):
+    if env.get("is_error") or env.get("subtype") not in cli_contract.SUCCESS_SUBTYPES:
         detail = (env.get("result") or "").strip() or (env.get("subtype") or "unknown error")
+        # A drift signature can arrive as a zero-exit is_error envelope (not just a
+        # nonzero exit), so classify it the same way here.
+        if cli_contract.is_contract_drift(env.get("result"), env.get("subtype")):
+            return _error(contract_changed_error(), meta)
         return _error(
             ErrorInfo(
                 code="nonzero_exit",

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/preflight.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/preflight.py
@@ -1,0 +1,91 @@
+"""Feature-detect which `claude` flags exist, by parsing `claude --help` once.
+
+Only the HELP_GATED flags (depth/cosmetic) are gated on this probe: dropping one
+when absent keeps the server working across a minor upstream change. The
+guarantee-bearing ALWAYS_SEND flags are never gated here — their removal is caught
+loudly at run time (cli_contract_changed), not silently pre-empted, because
+`--help` parsing is fuzzy and a false negative must never drop a safety/cost flag.
+
+Everything degrades, nothing crashes: any probe failure yields help_parsed=False,
+which makes is_supported() return True for every flag (fail open == today's
+behavior)."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import time
+from dataclasses import dataclass
+
+from cc_plugin_codex import cli_contract
+
+_LONG_FLAG_RE = re.compile(r"--[a-z][a-z0-9-]+")
+
+
+@dataclass(frozen=True)
+class FlagSupport:
+    supported: frozenset[str]
+    help_parsed: bool   # False => probe failed; callers must fail open
+
+
+# Process-level cache: (monotonic_timestamp, FlagSupport). A long-lived MCP server
+# re-probes after HELP_CACHE_TTL_SECONDS so an in-place `claude` upgrade is noticed.
+_cache: tuple[float, FlagSupport] | None = None
+
+
+def _probe_help() -> str:
+    """Return the combined `claude --help` text, or "" on any failure. Never raises."""
+    try:
+        proc = subprocess.run(
+            [cli_contract.CLAUDE_BIN, *cli_contract.HELP_ARGS],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return f"{proc.stdout}\n{proc.stderr}"
+
+
+def _parse_supported(help_text: str) -> frozenset[str]:
+    """Extract long-flag names from help text. Deliberately tolerant: this only
+    governs HELP_GATED flags, where a stray/missing match drops a harmless flag."""
+    return frozenset(_LONG_FLAG_RE.findall(help_text))
+
+
+def flag_support(force: bool = False) -> FlagSupport:
+    """Cached FlagSupport for the installed `claude`. force=True bypasses the cache
+    (used by tests / diagnostics)."""
+    global _cache
+    now = time.monotonic()
+    if not force and _cache is not None:
+        stamped, value = _cache
+        if now - stamped < cli_contract.HELP_CACHE_TTL_SECONDS:
+            return value
+    help_text = _probe_help()
+    if not help_text.strip():
+        value = FlagSupport(supported=frozenset(), help_parsed=False)
+    else:
+        value = FlagSupport(supported=_parse_supported(help_text), help_parsed=True)
+    _cache = (now, value)
+    return value
+
+
+def reset_cache() -> None:
+    """Drop the cached probe (used by tests)."""
+    global _cache
+    _cache = None
+
+
+def is_supported(flag: str, fs: FlagSupport) -> bool:
+    """Whether `flag` may be sent. Fails OPEN: when the probe could not run
+    (help_parsed=False) every flag is treated as supported, preserving today's
+    behavior."""
+    return (not fs.help_parsed) or (flag in fs.supported)
+
+
+def missing_expected_flags(fs: FlagSupport) -> list[str]:
+    """Guarantee-bearing ALWAYS_SEND flags that `--help` did not list. Empty when
+    the probe could not run (so we never warn on a failed probe). Diagnostic only —
+    surfaced by claude_status, it does NOT gate execution."""
+    if not fs.help_parsed:
+        return []
+    return sorted(f for f in cli_contract.ALWAYS_SEND_FLAGS if f not in fs.supported)

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/schemas.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/schemas.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 # Bump this whenever the agent-visible surface changes: tool names, input or
 # output schemas, the ErrorCode set, the config_mode/access/scope/detail value
 # sets, or the capability guarantees in CAPABILITY_SUMMARY. Clients cache by it.
-FINGERPRINT = "cc-plugin-codex/0.1/schema-10"
+FINGERPRINT = "cc-plugin-codex/0.1/schema-11"
 
 Severity = Literal["critical", "high", "medium", "low", "nit"]
 Verdict = Literal["pass", "concerns", "fail", "unknown"]
@@ -45,6 +45,9 @@ ErrorCode = Literal[
     "invalid_workspace_root", "workspace_outside_roots",
     "context_too_large", "timeout", "budget_exceeded", "claude_permission_error",
     "nonzero_exit", "invalid_json", "internal_error",
+    # The installed `claude` rejected a flag/value this plugin sends — its CLI
+    # contract drifted and the plugin likely needs an update.
+    "cli_contract_changed",
     # Background-job lifecycle errors (claude_job_result for a non-done job):
     "job_not_found", "job_running", "job_cancelled", "job_timeout", "job_failed",
 ]
@@ -103,6 +106,10 @@ class Meta(BaseModel):
     truncation_hint: Optional[str] = None
     command_exit_code: Optional[int] = None
     permission_denials: Optional[list] = None
+    # Optional `claude` flags this server dropped because the installed CLI did not
+    # advertise them in --help (e.g. ["--effort"]). Empty in the common case;
+    # informational — guarantee-bearing flags are never dropped, only depth/cosmetic ones.
+    compat_warnings: list[str] = Field(default_factory=list)
     redacted_paths: list[str] = Field(default_factory=list)
     cost_usd: Optional[float] = None
     usage: Optional[Usage] = None
@@ -163,8 +170,14 @@ class StatusResult(BaseModel):
     # Readiness probes (all free — no paid Claude call):
     claude_authenticated: Optional[bool] = None   # None = could not determine
     auth_detail: Optional[str] = None
-    version_supported: Optional[bool] = None       # matches the supported CLI major
-    ready: bool = False        # found AND a supported version AND authenticated
+    version_supported: Optional[bool] = None       # major is in supported_majors()
+    # Set when version_supported is False: a major outside the tested range is
+    # advisory, not fatal — tools may still work, so we warn instead of blocking.
+    version_warning: Optional[str] = None
+    # Set when `claude --help` did not list a guarantee-bearing flag this plugin
+    # sends — an early, free signal that the CLI contract drifted.
+    flags_warning: Optional[str] = None
+    ready: bool = False        # found AND authenticated (version is advisory, not gating)
     config_modes_available: dict
     resolved_defaults: ResolvedDefaults
     caveat: str

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
@@ -792,7 +792,7 @@ def claude_status() -> ToolResult:
     Free and read-only. Use first when unsure whether paid tools can run, or to
     inspect config_mode/access/model/effort/budget/timeout defaults.
     """
-    found = shutil.which("claude") is not None
+    found = shutil.which(cli_contract.CLAUDE_BIN) is not None
     version = None
     authenticated: bool | None = None
     auth_detail: str | None = None

--- a/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
+++ b/plugins/cc-plugin-codex/src/cc_plugin_codex/server.py
@@ -15,14 +15,14 @@ from fastmcp import Context, FastMCP
 from fastmcp.tools.tool import ToolResult
 from pydantic import Field
 
-from cc_plugin_codex import __version__
+from cc_plugin_codex import __version__, cli_contract, preflight
 from cc_plugin_codex.claude import (
     auth_status, build_command, classify_failure, run_claude_async,
 )
 from cc_plugin_codex.config import (
     MAX_BUDGET_USD, MAX_TIMEOUT_SECONDS, MIN_BUDGET_USD, MIN_TIMEOUT_SECONDS,
     VALID_EFFORTS, bare_available, clamp_budget, clamp_timeout, defaults,
-    max_input_bytes, sanitize_effort, version_supported,
+    max_input_bytes, sanitize_effort, supported_majors, version_supported,
 )
 from cc_plugin_codex.context import (
     MAX_DIFF_BYTES, InvalidBaseError, InvalidScopeError, gather_context,
@@ -89,14 +89,16 @@ def _meta(cwd: str, config_mode: str, access: str, timeout: int, elapsed: int,
           truncated: bool = False, hint: str | None = None,
           workspace_source: str | None = None,
           requested_budget: float | None = None,
-          redacted_paths: list[str] | None = None) -> Meta:
+          redacted_paths: list[str] | None = None,
+          compat_warnings: list[str] | None = None) -> Meta:
     return Meta(cwd=cwd, config_mode=config_mode, access=access, scope=scope, base=base,
                 timeout_seconds=timeout, elapsed_ms=elapsed, command_exit_code=exit_code,
                 truncated=truncated, truncation_hint=hint, fingerprint=FINGERPRINT,
                 workspace_source=workspace_source,
                 workspace_warning=workspace_warning_for(workspace_source, cwd),
                 requested_max_budget_usd=requested_budget,
-                redacted_paths=redacted_paths or [])
+                redacted_paths=redacted_paths or [],
+                compat_warnings=compat_warnings or [])
 
 
 def _err(code: str, message: str, repair: str, meta: Meta,
@@ -279,11 +281,11 @@ async def _execute(tool, payload, r: Resolved, cwd,
                    scope=None, base=None, context_text="", context_summary=None,
                    workspace_source=None, redacted_paths: list[str] | None = None) -> dict:
     prompt = build_prompt(tool, payload, context_text)
-    cmd = build_command(prompt, r.config_mode, r.access, r.model, r.budget, r.effort)
+    cmd, dropped = build_command(prompt, r.config_mode, r.access, r.model, r.budget, r.effort)
     run = await run_claude_async(cmd, cwd=cwd, timeout_seconds=r.timeout)
     meta = _meta(cwd, r.config_mode, r.access, r.timeout, run.elapsed_ms, run.exit_code,
                  scope, base, workspace_source=workspace_source, requested_budget=r.budget,
-                 redacted_paths=redacted_paths)
+                 redacted_paths=redacted_paths, compat_warnings=dropped)
     if run.exit_code != 0 or run.timed_out:
         # A non-zero exit can still carry a cost-bearing JSON envelope (e.g.
         # budget_exceeded); report what it spent when available.
@@ -587,7 +589,7 @@ async def claude_review_changes_async(
         return _result(_empty_diff_result("claude_review_changes", meta, ctx_data.summary))
     prompt = build_prompt("claude_review_changes",
                           {"scope": scope, "base": base, "focus": focus}, ctx_data.text)
-    cmd = build_command(prompt, r.config_mode, r.access, r.model, r.budget, r.effort)
+    cmd, dropped = build_command(prompt, r.config_mode, r.access, r.model, r.budget, r.effort)
     cfg = JobConfig(kind="claude_review_changes", config_mode=r.config_mode,
                     access=r.access, scope=scope, base=base, detail=r.detail,
                     timeout_seconds=jobs.max_seconds(), workspace_source=ws_source,
@@ -602,7 +604,7 @@ async def claude_review_changes_async(
         ttl_seconds=jobs.ttl_seconds(),
         meta=_meta(cwd, r.config_mode, r.access, job_timeout, 0, None, scope, base,
                    workspace_source=ws_source, requested_budget=r.budget,
-                   redacted_paths=ctx_data.redacted_paths),
+                   redacted_paths=ctx_data.redacted_paths, compat_warnings=dropped),
     )
     return _result(started.model_dump(mode="json", exclude_none=True))
 
@@ -795,16 +797,33 @@ def claude_status() -> ToolResult:
     authenticated: bool | None = None
     auth_detail: str | None = None
     supported: bool | None = None
+    version_warning: str | None = None
+    flags_warning: str | None = None
     if found:
         try:
-            version = subprocess.run(["claude", "--version"], capture_output=True,
-                                     text=True, timeout=10).stdout.strip()
+            version = subprocess.run(
+                [cli_contract.CLAUDE_BIN, *cli_contract.VERSION_ARGS],
+                capture_output=True, text=True, timeout=10).stdout.strip()
         except Exception:
             version = None
         supported = version_supported(version)
+        if supported is False:
+            version_warning = (
+                f"installed claude version {version!r} is outside this plugin's "
+                f"tested major(s) {sorted(supported_majors())}; tools may still work — "
+                "file an issue if they do not, or set "
+                f"{cli_contract.SUPPORTED_MAJORS_ENV} to silence this")
         # Free auth probe: lets an agent discover a logged-out CLI before
         # spending money on a paid call that would only then fail auth.
         authenticated, auth_detail = auth_status()
+        # Free flag-contract probe: warn if a guarantee-bearing flag is missing
+        # from `claude --help` (an early drift signal), without gating execution.
+        missing = preflight.missing_expected_flags(preflight.flag_support())
+        if missing:
+            flags_warning = (
+                "claude --help did not list expected flags: "
+                f"{', '.join(missing)}; the plugin may need an update for your "
+                "claude version")
     d = defaults()
     resolved = ResolvedDefaults(
         config_mode=d.config_mode if d.config_mode in ("inherit", "scoped", "bare") else "inherit",
@@ -822,7 +841,12 @@ def claude_status() -> ToolResult:
         claude_authenticated=authenticated,
         auth_detail=auth_detail,
         version_supported=supported,
-        ready=bool(found and supported and authenticated),
+        version_warning=version_warning,
+        flags_warning=flags_warning,
+        # Version is advisory, not gating: a major outside the tested range warns
+        # (version_warning) but does not flip ready, so a claude major bump no
+        # longer self-blocks an authenticated, installed CLI.
+        ready=bool(found and authenticated),
         config_modes_available={
             "inherit": True, "scoped": True, "bare": bare_available(),
         },

--- a/plugins/cc-plugin-codex/tests/golden/claude_envelope.json
+++ b/plugins/cc-plugin-codex/tests/golden/claude_envelope.json
@@ -1,0 +1,15 @@
+{
+  "type": "result",
+  "subtype": "success",
+  "is_error": false,
+  "result": "{\"summary\": \"Off-by-one in add()\", \"verdict\": \"concerns\", \"confidence\": \"high\", \"findings\": [{\"severity\": \"high\", \"title\": \"subtraction instead of addition\", \"file\": \"app.py\", \"line\": 2, \"evidence\": \"return a - b\", \"risk\": \"wrong result\", \"recommendation\": \"use +\"}], \"questions\": [], \"assumptions\": [], \"next_steps\": [\"fix the operator\"]}",
+  "session_id": "sess-golden-1",
+  "modelUsage": {"claude-sonnet-4-6": {"inputTokens": 100, "outputTokens": 50}},
+  "total_cost_usd": 0.0123,
+  "usage": {
+    "input_tokens": 100,
+    "output_tokens": 50,
+    "cache_read_input_tokens": 10,
+    "cache_creation_input_tokens": 5
+  }
+}

--- a/plugins/cc-plugin-codex/tests/test_claude.py
+++ b/plugins/cc-plugin-codex/tests/test_claude.py
@@ -3,6 +3,15 @@ import anyio
 from cc_plugin_codex.claude import (
     build_command, classify_failure, run_claude_async, ClaudeRun,
 )
+from cc_plugin_codex.cli_contract import ALWAYS_SEND_FLAGS, HELP_GATED_FLAGS
+from cc_plugin_codex.preflight import FlagSupport
+
+# Probe could not run -> fail open: every flag is treated as supported, so these
+# tests are deterministic and never shell out to a real `claude --help`.
+_NO_PROBE = FlagSupport(supported=frozenset(), help_parsed=False)
+# A successful probe that lists every flag this plugin knows about.
+_ALL_FLAGS = FlagSupport(
+    supported=frozenset(ALWAYS_SEND_FLAGS) | set(HELP_GATED_FLAGS), help_parsed=True)
 
 
 async def test_run_claude_async_returns_output():
@@ -36,8 +45,8 @@ async def test_run_claude_async_cancellation_kills_process(tmp_path):
 
 
 def test_build_command_toolless_inherit():
-    cmd = build_command(prompt="hi", config_mode="inherit", access="toolless",
-                        model=None, max_budget_usd=1.0)
+    cmd, dropped = build_command(prompt="hi", config_mode="inherit", access="toolless",
+                                 model=None, max_budget_usd=1.0, flag_support=_NO_PROBE)
     assert cmd[0] == "claude"
     assert "-p" in cmd and "--output-format" in cmd and "json" in cmd
     assert "--no-chrome" in cmd  # avoid an interactive Chrome picker hanging the call
@@ -46,25 +55,66 @@ def test_build_command_toolless_inherit():
     assert "--append-system-prompt" in cmd
     assert cmd[-2] == "--"
     assert cmd[-1] == "hi"  # prompt is the final positional arg
+    assert dropped == []
 
 
 def test_build_command_effort_flag():
-    cmd = build_command(prompt="hi", config_mode="inherit", access="toolless",
-                        model=None, max_budget_usd=1.0, effort="xhigh")
+    cmd, _ = build_command(prompt="hi", config_mode="inherit", access="toolless",
+                           model=None, max_budget_usd=1.0, effort="xhigh",
+                           flag_support=_NO_PROBE)
     assert "--effort" in cmd
     assert cmd[cmd.index("--effort") + 1] == "xhigh"
 
 
 def test_build_command_omits_effort_when_none():
-    cmd = build_command(prompt="hi", config_mode="inherit", access="toolless",
-                        model=None, max_budget_usd=1.0)
+    cmd, _ = build_command(prompt="hi", config_mode="inherit", access="toolless",
+                           model=None, max_budget_usd=1.0, flag_support=_NO_PROBE)
     assert "--effort" not in cmd
 
 
 def test_build_command_model():
-    cmd = build_command(prompt="hi", config_mode="inherit", access="readonly",
-                        model="sonnet", max_budget_usd=2.0)
+    cmd, _ = build_command(prompt="hi", config_mode="inherit", access="readonly",
+                           model="sonnet", max_budget_usd=2.0, flag_support=_ALL_FLAGS)
     assert "--model" in cmd and "sonnet" in cmd
+
+
+def test_build_command_always_send_flags_survive_when_probe_lists_them():
+    # A successful probe that DOESN'T list a guarantee-bearing flag must not drop
+    # it: such flags are never gated. Only the run-time error path catches their loss.
+    partial = FlagSupport(supported=frozenset({"--effort"}), help_parsed=True)
+    cmd, dropped = build_command(prompt="hi", config_mode="inherit", access="toolless",
+                                 model=None, max_budget_usd=1.0, effort="high",
+                                 flag_support=partial)
+    assert "--tools" in cmd                 # guarantee-bearing: always sent
+    assert "--max-budget-usd" in cmd
+    assert "--append-system-prompt" in cmd
+    assert "--effort" in cmd                # listed by the probe -> kept
+    # --no-session-persistence is HELP_GATED and absent from this probe -> dropped
+    assert "--no-session-persistence" not in cmd
+    assert "--no-session-persistence" in dropped
+
+
+def test_build_command_drops_unsupported_help_gated_flag():
+    # Probe lists everything EXCEPT --effort -> --effort (and its value) dropped.
+    supported = (frozenset(ALWAYS_SEND_FLAGS) | set(HELP_GATED_FLAGS)) - {"--effort"}
+    cmd, dropped = build_command(prompt="hi", config_mode="inherit", access="readonly",
+                                 model="sonnet", max_budget_usd=1.0, effort="xhigh",
+                                 flag_support=FlagSupport(supported=supported, help_parsed=True))
+    assert "--effort" not in cmd
+    assert "xhigh" not in cmd                # the value token went with the flag
+    assert "--effort" in dropped
+    assert "--model" in cmd and "sonnet" in cmd  # still supported -> kept
+
+
+def test_build_command_separates_prompt_even_if_prompt_looks_like_flag():
+    # The prompt is appended AFTER gating, so a prompt that contains a gated flag
+    # name is never mistaken for one.
+    cmd, _ = build_command(prompt="--effort evil", config_mode="inherit",
+                           access="toolless", model=None, max_budget_usd=1.0,
+                           flag_support=FlagSupport(supported=frozenset(),
+                                                    help_parsed=True))
+    assert cmd[-2] == "--"
+    assert cmd[-1] == "--effort evil"
 
 
 def test_classify_not_logged_in():
@@ -137,7 +187,26 @@ def test_classify_malformed_structured_error_falls_back():
 
 
 def test_build_command_separates_prompt_with_double_dash():
-    cmd = build_command(prompt="--model evil", config_mode="inherit", access="toolless",
-                        model=None, max_budget_usd=1.0)
+    cmd, _ = build_command(prompt="--model evil", config_mode="inherit", access="toolless",
+                           model=None, max_budget_usd=1.0, flag_support=_NO_PROBE)
     assert cmd[-2] == "--"
     assert cmd[-1] == "--model evil"  # flag-looking prompt stays a positional
+
+
+def test_classify_unknown_flag_is_cli_contract_changed():
+    run = ClaudeRun(stdout="", stderr="error: unknown option '--effort'",
+                    exit_code=2, elapsed_ms=5, timed_out=False)
+    assert classify_failure(run).code == "cli_contract_changed"
+
+
+def test_classify_invalid_effort_value_is_cli_contract_changed():
+    run = ClaudeRun(stdout="", stderr="error: invalid choice: 'xhigh'",
+                    exit_code=2, elapsed_ms=5, timed_out=False)
+    assert classify_failure(run).code == "cli_contract_changed"
+
+
+def test_classify_auth_not_misread_as_contract_drift():
+    # An auth failure must win over the drift check even if wording overlaps.
+    run = ClaudeRun(stdout="", stderr="Not logged in · Please run /login",
+                    exit_code=1, elapsed_ms=5, timed_out=False)
+    assert classify_failure(run).code == "claude_auth_required"

--- a/plugins/cc-plugin-codex/tests/test_cli_contract.py
+++ b/plugins/cc-plugin-codex/tests/test_cli_contract.py
@@ -1,0 +1,54 @@
+"""Canary tests for the centralized CLI contract.
+
+These guard against a careless edit silently emptying a constant set or letting
+config.py emit a flag the contract does not classify."""
+
+from cc_plugin_codex import cli_contract
+from cc_plugin_codex.config import access_flags, config_mode_flags
+
+
+def test_core_and_effort_constants_present():
+    assert cli_contract.CLAUDE_BIN == "claude"
+    assert "-p" in cli_contract.CORE_INVOCATION
+    assert "json" in cli_contract.CORE_INVOCATION
+    assert "xhigh" in cli_contract.VALID_EFFORTS
+    assert cli_contract.DEFAULT_EFFORT in cli_contract.VALID_EFFORTS
+    assert cli_contract.SUPPORTED_MAJORS  # non-empty
+
+
+def test_flag_classes_are_disjoint_and_nonempty():
+    assert cli_contract.ALWAYS_SEND_FLAGS
+    assert cli_contract.HELP_GATED_FLAGS
+    assert not (cli_contract.ALWAYS_SEND_FLAGS & set(cli_contract.HELP_GATED_FLAGS))
+
+
+def test_security_flags_are_always_send():
+    # Losing any of these silently would weaken a security/cost/behavioral
+    # guarantee, so they must never be in the help-gated (droppable) class.
+    for flag in ("--tools", "--strict-mcp-config", "--mcp-config",
+                 "--max-budget-usd", "--append-system-prompt"):
+        assert flag in cli_contract.ALWAYS_SEND_FLAGS
+        assert flag not in cli_contract.HELP_GATED_FLAGS
+
+
+def test_every_emitted_flag_is_classified():
+    # Whatever config.py actually emits must be a flag the contract knows about, so
+    # the gate and the diagnostic never miss a real flag. (Skips non-flag tokens
+    # like values and the empty --tools argument.)
+    known = set(cli_contract.ALWAYS_SEND_FLAGS) | set(cli_contract.HELP_GATED_FLAGS)
+    emitted = []
+    for mode in ("inherit", "scoped", "bare"):
+        emitted += config_mode_flags(mode)
+    for access in ("toolless", "readonly"):
+        emitted += access_flags(access)
+    for token in emitted:
+        if token.startswith("--"):
+            assert token in known, f"{token} is emitted but not classified in cli_contract"
+
+
+def test_is_contract_drift_matches_known_phrasings():
+    assert cli_contract.is_contract_drift("error: unknown option '--effort'")
+    assert cli_contract.is_contract_drift("invalid choice: 'xhigh'")
+    assert cli_contract.is_contract_drift(None, "Unrecognized argument")  # case-insensitive
+    assert not cli_contract.is_contract_drift("not logged in")
+    assert not cli_contract.is_contract_drift(None, None)

--- a/plugins/cc-plugin-codex/tests/test_config.py
+++ b/plugins/cc-plugin-codex/tests/test_config.py
@@ -93,3 +93,16 @@ def test_version_supported():
     assert cfg.version_supported("3.0.0") is False
     assert cfg.version_supported("garbage") is None
     assert cfg.version_supported(None) is None
+
+
+def test_supported_majors_env_override(monkeypatch):
+    # A user can opt into an untested major without a code change.
+    monkeypatch.setenv("CC_PLUGIN_CODEX_SUPPORTED_MAJORS", "2,3")
+    assert cfg.supported_majors() == frozenset({2, 3})
+    assert cfg.version_supported("3.0.0") is True
+    assert cfg.version_supported("4.1.0") is False
+
+
+def test_supported_majors_env_garbage_falls_back(monkeypatch):
+    monkeypatch.setenv("CC_PLUGIN_CODEX_SUPPORTED_MAJORS", "not,ints")
+    assert cfg.supported_majors() == cfg.cli_contract.SUPPORTED_MAJORS

--- a/plugins/cc-plugin-codex/tests/test_golden_envelope.py
+++ b/plugins/cc-plugin-codex/tests/test_golden_envelope.py
@@ -1,0 +1,30 @@
+"""Golden-file test pinning the `claude -p --output-format json` envelope shape.
+
+If an upstream rename of an envelope key (or a refactor of normalize.py) breaks
+parsing, this fails loudly against a recorded real envelope — without needing the
+live CLI. Update tests/golden/claude_envelope.json when the upstream shape
+legitimately changes."""
+
+from pathlib import Path
+
+from cc_plugin_codex.normalize import normalize_envelope
+from cc_plugin_codex.schemas import FINGERPRINT, Meta
+
+_GOLDEN = (Path(__file__).parent / "golden" / "claude_envelope.json").read_text()
+
+
+def _meta():
+    return Meta(cwd="/repo", config_mode="inherit", access="toolless",
+                timeout_seconds=180, elapsed_ms=10, fingerprint=FINGERPRINT)
+
+
+def test_golden_envelope_parses_to_success_with_cost():
+    out = normalize_envelope("claude_review_changes", _GOLDEN, _meta(), detail="full")
+    assert out["ok"] is True
+    assert out["verdict"] == "concerns"
+    assert out["confidence"] == "high"
+    assert out["findings"][0]["severity"] == "high"
+    # Cost and usage must be plumbed off the envelope onto meta.
+    assert out["meta"]["cost_usd"] == 0.0123
+    assert out["meta"]["usage"]["input_tokens"] == 100
+    assert out["meta"]["usage"]["cache_read_input_tokens"] == 10

--- a/plugins/cc-plugin-codex/tests/test_jobs.py
+++ b/plugins/cc-plugin-codex/tests/test_jobs.py
@@ -43,6 +43,12 @@ def _sleep_cmd(seconds=30):
     return ["sh", "-c", f"sleep {seconds}"]
 
 
+def _drift_cmd(message="error: unknown option '--effort'"):
+    # Write a contract-drift signature to stderr and leave stdout (result.json)
+    # empty, so the job is "failed" with a drift-bearing stderr tail.
+    return ["sh", "-c", "printf '%s' \"$0\" 1>&2; exit 2", message]
+
+
 @pytest.fixture(autouse=True)
 def _state_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("CC_PLUGIN_CODEX_STATE_DIR", str(tmp_path / "state"))
@@ -190,3 +196,27 @@ def test_consume_deletes_record(tmp_path):
     payload, found = jobs.result(cwd, job_id, consume=True)
     assert found is True and payload["ok"] is True
     assert jobs.status(cwd, job_id) is None  # gone after consume
+
+
+def test_failed_job_with_drift_stderr_is_cli_contract_changed(tmp_path):
+    # The async twin of the sync cli_contract_changed path: a job that exits
+    # nonzero with an unknown-flag stderr must classify as cli_contract_changed,
+    # not a generic job_failed.
+    cwd = str(tmp_path)
+    job_id, _ = jobs.start_job(_drift_cmd(), cwd, _cfg())
+    st = _await_done(cwd, job_id)
+    assert st["status"] == "failed"
+    payload, found = jobs.result(cwd, job_id)
+    assert found is True
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "cli_contract_changed"
+
+
+def test_failed_job_without_drift_stays_job_failed(tmp_path):
+    cwd = str(tmp_path)
+    job_id, _ = jobs.start_job(
+        ["sh", "-c", "printf 'boom' 1>&2; exit 1"], cwd, _cfg())
+    _await_done(cwd, job_id)
+    payload, found = jobs.result(cwd, job_id)
+    assert found is True
+    assert payload["error"]["code"] == "job_failed"

--- a/plugins/cc-plugin-codex/tests/test_normalize.py
+++ b/plugins/cc-plugin-codex/tests/test_normalize.py
@@ -171,3 +171,20 @@ def test_normalize_reports_cost_on_error_envelope():
     assert res["ok"] is False
     assert res["meta"]["cost_usd"] == 0.004
     assert res["meta"]["usage"]["input_tokens"] == 20
+
+
+def test_zero_exit_is_error_drift_is_cli_contract_changed():
+    # A drift signature can arrive as a zero-exit envelope with is_error=true, not
+    # only as a nonzero process exit; normalize_envelope must label it too.
+    env = json.dumps({"type": "result", "is_error": True, "subtype": "error",
+                      "result": "error: unknown option '--effort'"})
+    out = normalize_envelope("claude_review_changes", env, _meta(), detail="summary")
+    assert out["ok"] is False
+    assert out["error"]["code"] == "cli_contract_changed"
+
+
+def test_zero_exit_is_error_without_drift_stays_nonzero_exit():
+    env = json.dumps({"type": "result", "is_error": True, "subtype": "error",
+                      "result": "the model declined to answer"})
+    out = normalize_envelope("claude_review_changes", env, _meta(), detail="summary")
+    assert out["error"]["code"] == "nonzero_exit"

--- a/plugins/cc-plugin-codex/tests/test_preflight.py
+++ b/plugins/cc-plugin-codex/tests/test_preflight.py
@@ -1,0 +1,56 @@
+"""Tests for the `claude --help` flag feature-detection (preflight)."""
+
+from cc_plugin_codex import cli_contract, preflight
+from cc_plugin_codex.preflight import FlagSupport
+
+
+def test_parse_supported_extracts_long_flags():
+    help_text = "Usage: claude -p [options]\n  --effort <level>\n  --no-chrome\n  -m, --model"
+    supported = preflight._parse_supported(help_text)
+    assert "--effort" in supported
+    assert "--no-chrome" in supported
+    assert "--model" in supported
+
+
+def test_flag_support_fails_open_when_probe_empty(monkeypatch):
+    # Probe failed (claude missing / timed out) -> help_parsed False -> everything
+    # is treated as supported, preserving today's behavior.
+    monkeypatch.setattr(preflight, "_probe_help", lambda: "")
+    preflight.reset_cache()
+    fs = preflight.flag_support(force=True)
+    assert fs.help_parsed is False
+    assert preflight.is_supported("--effort", fs) is True
+    assert preflight.is_supported("--anything", fs) is True
+
+
+def test_is_supported_when_help_parsed():
+    fs = FlagSupport(supported=frozenset({"--effort"}), help_parsed=True)
+    assert preflight.is_supported("--effort", fs) is True
+    assert preflight.is_supported("--model", fs) is False
+
+
+def test_flag_support_caches(monkeypatch):
+    calls = {"n": 0}
+
+    def _probe():
+        calls["n"] += 1
+        return "--effort\n--model"
+
+    monkeypatch.setattr(preflight, "_probe_help", _probe)
+    preflight.reset_cache()
+    preflight.flag_support(force=True)
+    preflight.flag_support()  # cached -> no second probe
+    assert calls["n"] == 1
+
+
+def test_missing_expected_flags_reports_absent_always_send():
+    # A guarantee-bearing flag absent from a *successful* probe is reported as a
+    # drift signal.
+    present = frozenset(cli_contract.ALWAYS_SEND_FLAGS) - {"--tools"}
+    fs = FlagSupport(supported=present, help_parsed=True)
+    assert "--tools" in preflight.missing_expected_flags(fs)
+
+
+def test_missing_expected_flags_empty_when_probe_failed():
+    fs = FlagSupport(supported=frozenset(), help_parsed=False)
+    assert preflight.missing_expected_flags(fs) == []

--- a/plugins/cc-plugin-codex/tests/test_schemas.py
+++ b/plugins/cc-plugin-codex/tests/test_schemas.py
@@ -44,7 +44,7 @@ def test_success_result_has_next_steps():
 
 
 def test_fingerprint_value():
-    assert FINGERPRINT == "cc-plugin-codex/0.1/schema-10"
+    assert FINGERPRINT == "cc-plugin-codex/0.1/schema-11"
 
 
 def test_success_result_dump_omits_none():

--- a/plugins/cc-plugin-codex/tests/test_server.py
+++ b/plugins/cc-plugin-codex/tests/test_server.py
@@ -4,11 +4,22 @@ import anyio
 import pytest
 from fastmcp import Client
 
+from cc_plugin_codex.cli_contract import ALWAYS_SEND_FLAGS, HELP_GATED_FLAGS
+from cc_plugin_codex.preflight import FlagSupport
 from cc_plugin_codex.server import CAPABILITY_SUMMARY, mcp
 from cc_plugin_codex.server import _first_root, _resolve_workspace
 from tests.conftest import structured
 
 PAID_TOOLS = ("claude_ask", "claude_review_changes", "claude_adversarial_review")
+
+
+def _patch_full_flag_support(monkeypatch):
+    """Make claude_status' --help probe deterministic: every expected flag present,
+    so flags_warning stays None and no real `claude --help` runs."""
+    import cc_plugin_codex.server as srv
+    fs = FlagSupport(
+        supported=frozenset(ALWAYS_SEND_FLAGS) | set(HELP_GATED_FLAGS), help_parsed=True)
+    monkeypatch.setattr(srv.preflight, "flag_support", lambda *a, **k: fs)
 
 
 class _FakeRoots:
@@ -199,7 +210,7 @@ async def test_claude_ask_returns_normalized(fake_claude):
     data = structured(result)
     assert data["ok"] is True
     assert data["verdict"] == "concerns"
-    assert data["meta"]["fingerprint"] == "cc-plugin-codex/0.1/schema-10"
+    assert data["meta"]["fingerprint"] == "cc-plugin-codex/0.1/schema-11"
 
 
 async def test_claude_ask_rejects_oversized_prompt_before_paid_call(monkeypatch, tmp_path):
@@ -316,12 +327,36 @@ async def test_status_reports_readiness(monkeypatch):
 
     monkeypatch.setattr(srv.subprocess, "run", lambda *a, **k: _Ver())
     monkeypatch.setattr(srv, "auth_status", lambda *a, **k: (True, "Logged in"))
+    _patch_full_flag_support(monkeypatch)
     async with Client(mcp) as client:
         result = await client.call_tool("claude_status", {})
     data = structured(result)
     assert data["claude_authenticated"] is True
     assert data["version_supported"] is True
     assert data["ready"] is True
+    assert "version_warning" not in data    # supported version -> no warning
+    assert "flags_warning" not in data      # probe lists every expected flag
+
+
+async def test_status_ready_despite_untested_major(monkeypatch):
+    # A claude major outside the tested range is advisory: ready stays True (so an
+    # agent does not self-block) but version_warning explains the mismatch.
+    import cc_plugin_codex.server as srv
+
+    monkeypatch.setattr(srv.shutil, "which", lambda _: "/usr/bin/claude")
+
+    class _Ver:
+        stdout = "3.0.0 (Claude Code)"
+
+    monkeypatch.setattr(srv.subprocess, "run", lambda *a, **k: _Ver())
+    monkeypatch.setattr(srv, "auth_status", lambda *a, **k: (True, "Logged in"))
+    _patch_full_flag_support(monkeypatch)
+    async with Client(mcp) as client:
+        result = await client.call_tool("claude_status", {})
+    data = structured(result)
+    assert data["version_supported"] is False
+    assert data["ready"] is True            # version no longer gates readiness
+    assert "version_warning" in data and "3.0.0" in data["version_warning"]
 
 
 async def test_status_not_ready_when_logged_out(monkeypatch):
@@ -334,6 +369,7 @@ async def test_status_not_ready_when_logged_out(monkeypatch):
 
     monkeypatch.setattr(srv.subprocess, "run", lambda *a, **k: _Ver())
     monkeypatch.setattr(srv, "auth_status", lambda *a, **k: (False, "Not logged in"))
+    _patch_full_flag_support(monkeypatch)
     async with Client(mcp) as client:
         result = await client.call_tool("claude_status", {})
     data = structured(result)
@@ -551,7 +587,7 @@ async def test_review_changes_async_lifecycle(monkeypatch, git_repo, tmp_path):
                             "result": _json.dumps(inner), "total_cost_usd": 0.02,
                             "usage": {"input_tokens": 5, "output_tokens": 1}})
     monkeypatch.setattr(srv, "build_command",
-                        lambda *a, **k: ["sh", "-c", "printf '%s' \"$0\"", envelope])
+                        lambda *a, **k: (["sh", "-c", "printf '%s' \"$0\"", envelope], []))
 
     async with Client(mcp) as client:
         started = structured(await client.call_tool(
@@ -608,7 +644,7 @@ async def test_job_consume_result_deletes_finished_record(monkeypatch, git_repo,
     envelope = _json.dumps({"type": "result", "subtype": "success", "is_error": False,
                             "result": _json.dumps(inner)})
     monkeypatch.setattr(srv, "build_command",
-                        lambda *a, **k: ["sh", "-c", "printf '%s' \"$0\"", envelope])
+                        lambda *a, **k: (["sh", "-c", "printf '%s' \"$0\"", envelope], []))
 
     async with Client(mcp) as client:
         started = structured(await client.call_tool(
@@ -642,7 +678,7 @@ async def test_capabilities_tool_returns_structured_contract():
     async with Client(mcp) as client:
         result = await client.call_tool("cc_codex_capabilities", {})
     data = structured(result)
-    assert data["fingerprint"] == "cc-plugin-codex/0.1/schema-10"
+    assert data["fingerprint"] == "cc-plugin-codex/0.1/schema-11"
     assert data["transport"] == "stdio"
     assert set(data["paid_tools"]) == {
         "claude_ask", "claude_review_changes", "claude_adversarial_review",
@@ -749,7 +785,7 @@ async def test_async_result_reports_redacted_paths(monkeypatch, git_repo, tmp_pa
     envelope = _json.dumps({"type": "result", "subtype": "success", "is_error": False,
                             "result": _json.dumps(inner)})
     monkeypatch.setattr(srv, "build_command",
-                        lambda *a, **k: ["sh", "-c", "printf '%s' \"$0\"", envelope])
+                        lambda *a, **k: (["sh", "-c", "printf '%s' \"$0\"", envelope], []))
 
     async with Client(mcp) as client:
         started = structured(await client.call_tool(
@@ -837,7 +873,7 @@ async def test_job_list_recovers_job_ids(monkeypatch, git_repo, tmp_path):
     envelope = _json.dumps({"type": "result", "subtype": "success", "is_error": False,
                             "result": _json.dumps(inner), "total_cost_usd": 0.02})
     monkeypatch.setattr(srv, "build_command",
-                        lambda *a, **k: ["sh", "-c", "printf '%s' \"$0\"", envelope])
+                        lambda *a, **k: (["sh", "-c", "printf '%s' \"$0\"", envelope], []))
 
     async with Client(mcp) as client:
         empty = structured(await client.call_tool(

--- a/plugins/cc-plugin-codex/uv.lock
+++ b/plugins/cc-plugin-codex/uv.lock
@@ -148,7 +148,7 @@ wheels = [
 
 [[package]]
 name = "cc-plugin-codex"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Why

`cc-plugin-codex` is squeezed between two fast-moving CLIs: it's loaded *into* Codex as an MCP plugin and shells out to the `claude` binary for reviews. Today an upstream breaking change fails confusingly — an unknown flag aborts a **paid** run as a generic `nonzero_exit`, a `claude` major bump silently flips `claude_status.ready` to `false`, and removing the `xhigh` effort level would make every call pass an invalid `--effort`.

This PR makes the plugin **degrade loudly and safely**: a guarantee is never silently weakened, and a contract break becomes an actionable, no-spend error.

## What changed

**Centralize** — new `cli_contract.py` holds every external assumption (flags, envelope keys, effort levels, version range, drift-stderr signatures) as named constants, so an upstream change is a one-file edit.

**Detect & label** — a dedicated `cli_contract_changed` error, wired into all **three** failure paths: sync `classify_failure`, the zero-exit `is_error` envelope (`normalize.py`), and the async `jobs._job_error`.

**Feature-detect & degrade** — a cached, fail-open `claude --help` probe (`preflight.py`). Flags split into two classes:
- **Always-send** (`--tools`, `--strict-mcp-config`/`--mcp-config`, `--max-budget-usd`, `--append-system-prompt`, `--no-chrome`, mode isolation) — never gated; removal fails closed at arg-parse (**zero spend**) → `cli_contract_changed`.
- **Help-gated droppable** (`--effort`, `--model`, `--disallowed-tools`, `--no-session-persistence`) — dropped-with-`compat_warnings` when absent.

**Version advisory** — `SUPPORTED_MAJORS` set + `CC_PLUGIN_CODEX_SUPPORTED_MAJORS` override; `ready` is now `found and authenticated` (no self-block on a major bump), with `version_warning`/`flags_warning` in `claude_status`.

**Docs & distribution** — `COMPATIBILITY.md` (assumption→code→detection→fix table, lockstep release process); `.mcp.json` pinned to tag `cc-plugin-codex-v0.1.3`; versions bumped to 0.1.3; `FINGERPRINT` → `schema-11`.

## Design note

The always-send/droppable split is the corrected design after a Codex review caught that the original "fail-open, gate everything" approach would silently drop security/cost/behavioral guarantees. Because a missing required flag fails at `claude`'s arg-parse before any model call, load-bearing flags fail loud and free without needing `--help` pre-detection — sidestepping the brittleness of parsing `--help`.

## Before merge / release
- ⚠️ **The `cc-plugin-codex-v0.1.3` git tag must be created at release** — `.mcp.json` points at it, so a bundled install won't resolve until the tag exists (documented in COMPATIBILITY.md).
- A few drift signatures are matched against a stderr **pattern set**; if a real `claude` phrases an unknown-flag error differently it falls through to `nonzero_exit` (safe, just less specific). Worth a one-time check against the live CLI.

## Testing
- `uv run pytest` — **181 passed** (new: `test_cli_contract`, `test_preflight`, `test_golden_envelope` + fixture; drift cases in `test_claude`/`test_normalize`/`test_jobs`; version/decoupling cases in `test_config`/`test_server`).
- `uv run ruff check` — clean. prek hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)