### PR TITLE
chore(cwms): bump to 0.3.0

### DIFF
--- a/plugins/cwms/.claude-plugin/plugin.json
+++ b/plugins/cwms/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cwms",
   "description": "MCP server for querying U.S. Army Corps of Engineers water data via the CWMS Data API",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "Brian Connelly"
   },
@@ -11,7 +11,7 @@
   "mcpServers": {
     "cwms-tools": {
       "command": "uvx",
-      "args": ["cwms-tools==0.2.0", "mcp", "serve"]
+      "args": ["cwms-tools==0.3.0", "mcp", "serve"]
     }
   }
 }

--- a/plugins/cwms/.codex-plugin/plugin.json
+++ b/plugins/cwms/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cwms",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "MCP server for querying U.S. Army Corps of Engineers water data via the CWMS Data API",
   "author": {
     "name": "Brian Connelly",

--- a/plugins/cwms/.mcp.json
+++ b/plugins/cwms/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "cwms-tools": {
       "command": "uvx",
-      "args": ["cwms-tools==0.2.0", "mcp", "serve"]
+      "args": ["cwms-tools==0.3.0", "mcp", "serve"]
     }
   }
 }


### PR DESCRIPTION
Bump cwms to 0.3.0 across all version pins:

- `plugins/cwms/.claude-plugin/plugin.json` — `version` and the `cwms-tools==0.3.0` MCP arg
- `plugins/cwms/.codex-plugin/plugin.json` — `version`
- `plugins/cwms/.mcp.json` — the `cwms-tools==0.3.0` MCP arg

🤖 Generated with [Claude Code](https://claude.com/claude-code)