### PR TITLE
feat(presence-detector): add presence-detector plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -53,6 +53,18 @@
       "category": "Utilities"
     },
     {
+      "name": "presence-detector",
+      "source": {
+        "source": "local",
+        "path": "./plugins/presence-detector"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Utilities"
+    },
+    {
       "name": "tempest",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,6 +32,12 @@
       "category": "utilities"
     },
     {
+      "name": "presence-detector",
+      "source": "./plugins/presence-detector",
+      "description": "Skill for detecting whether the user is present at or away from their macOS machine",
+      "category": "utilities"
+    },
+    {
       "name": "tempest",
       "source": "./plugins/tempest",
       "description": "MCP server for accessing WeatherFlow Tempest personal weather station data",

--- a/README.md
+++ b/README.md
@@ -27,5 +27,6 @@ In Codex, install plugins from the `briandconnelly-plugins` marketplace after ad
 | [ipinfo](plugins/ipinfo/) | MCP server for getting IP address details, location, and network information via ipinfo.io |
 | [orb-cloud](plugins/orb-cloud/) | MCP server for managing Orb Cloud organizations and devices |
 | [orbnet](plugins/orbnet/) | MCP server for monitoring internet quality via Orb Local API |
+| [presence-detector](plugins/presence-detector/) | Skill for detecting whether the user is present at or away from their macOS machine |
 | [tempest](plugins/tempest/) | MCP server for accessing WeatherFlow Tempest personal weather station data |
 | [voice-notify](plugins/voice-notify/) | Speak Claude Code Stop and Notification events aloud via macOS say |

--- a/plugins/presence-detector/.claude-plugin/plugin.json
+++ b/plugins/presence-detector/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "presence-detector",
+  "description": "Skill for detecting whether the user is present at or away from their macOS machine",
+  "version": "0.1.0",
+  "author": {
+    "name": "Brian Connelly"
+  },
+  "repository": "https://github.com/briandconnelly/briandconnelly-plugins",
+  "license": "MIT",
+  "keywords": ["presence", "idle", "focus", "macos", "automation"]
+}

--- a/plugins/presence-detector/.codex-plugin/plugin.json
+++ b/plugins/presence-detector/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "presence-detector",
+  "version": "0.1.0",
+  "description": "Skill for detecting whether the user is present at or away from their macOS machine",
+  "author": {
+    "name": "Brian Connelly",
+    "url": "https://github.com/briandconnelly"
+  },
+  "repository": "https://github.com/briandconnelly/briandconnelly-plugins",
+  "license": "MIT",
+  "keywords": ["presence", "idle", "focus", "macos", "automation"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Presence Detector",
+    "shortDescription": "Detect whether the user is at their macOS machine.",
+    "longDescription": "Presence Detector provides a skill that combines screen lock, screensaver, input idle time, and Focus mode into a single present/away verdict for macOS, suitable for presence-gating automations.",
+    "developerName": "Brian Connelly",
+    "category": "Utilities",
+    "capabilities": ["Skills"],
+    "defaultPrompt": [
+      "Am I currently at my machine?"
+    ]
+  }
+}

--- a/plugins/presence-detector/README.md
+++ b/plugins/presence-detector/README.md
@@ -1,0 +1,33 @@
+# presence-detector
+
+Skill that determines whether the user is **present** or **away** from a macOS machine by combining four independent signals, so no single false reading (e.g. watching a video with no input) flips the verdict on its own:
+
+- screen lock state (a deliberate "I'm leaving")
+- screensaver activity
+- input idle time (seconds since last mouse/keyboard event)
+- active Focus mode (counts as away only for modes you opt in)
+
+macOS-only.
+
+## Requirements
+
+- macOS (uses Quartz via PyObjC for lock and idle detection).
+- [`uv`](https://docs.astral.sh/uv/) — the script carries PEP 723 inline metadata, so `uv` provisions its one dependency in an ephemeral environment.
+
+## Usage
+
+Ask Claude things like "am I away from my machine?" or use the skill to presence-gate an automation.
+
+The underlying script can also be run directly:
+
+```bash
+uv run skills/presence-detector/scripts/presence.py                    # JSON verdict
+uv run skills/presence-detector/scripts/presence.py --idle 180         # >=180s idle counts as away (default 120)
+uv run skills/presence-detector/scripts/presence.py --away-focus Sleep,Personal
+```
+
+Exit code is `0` if present, `1` if away, and stdout carries a JSON `{status, reason, signals}` verdict — usable directly in launchd / shell guards.
+
+## Notes
+
+- Focus state is read from the undocumented Do Not Disturb database — best-effort, and may break on a major macOS release; every failure path safely reports no Focus mode.

--- a/plugins/presence-detector/skills/presence-detector/SKILL.md
+++ b/plugins/presence-detector/skills/presence-detector/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: presence-detector
+description: Use when checking whether the user is at their macOS machine — "am I away", idle/away detection, or presence-gating an automation. Combines screen lock, screensaver, input idle time, and Focus mode into one verdict. macOS only.
+---
+
+# Presence Detector
+
+Determines whether the user is **present** or **away** from a macOS machine by
+combining four independent signals, so no single false reading (e.g. watching a
+video with no input) flips the verdict on its own.
+
+## Running it
+
+The script carries PEP 723 inline metadata; run it with `uv`, which provisions
+the one dependency (PyObjC's Quartz) in an ephemeral environment.
+
+```bash
+uv run scripts/presence.py                      # JSON verdict
+uv run scripts/presence.py --idle 180           # >=180s idle counts as away (default 120)
+uv run scripts/presence.py --away-focus Sleep,Personal   # these Focus modes mean "away"
+```
+
+`scripts/presence.py` is `chmod +x` and uses a `uv run` shebang, so `./scripts/presence.py` also works.
+
+## Output
+
+- **Exit code:** `0` if present, `1` if away — usable directly in launchd / shell guards.
+- **stdout:** JSON `{status, reason, signals}` where `signals` carries the raw
+  `screen_locked`, `screensaver_running`, `idle_seconds`, and `focus_mode` readings.
+
+## Signal precedence
+
+The verdict is decided by the strongest, most deliberate signal first:
+
+1. **screen locked** → away (an explicit "I'm leaving")
+2. **screensaver active** → away
+3. **active Focus mode in `--away-focus`** → away (Focus is otherwise reported as context only)
+4. **idle ≥ threshold** → away (default 120s)
+5. otherwise → present
+
+## Notes
+
+- macOS only. Lock + idle detection use Quartz, which `uv` provisions from the
+  script's PEP 723 metadata.
+- Focus state is read from the undocumented Do Not Disturb database — best-effort,
+  may break on a major macOS release; every failure path returns `None` safely.

--- a/plugins/presence-detector/skills/presence-detector/scripts/presence.py
+++ b/plugins/presence-detector/skills/presence-detector/scripts/presence.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["pyobjc-framework-Quartz"]
+# ///
+"""Detect whether the user has stepped away from a macOS machine.
+
+Combines several independent signals so that no single false reading
+(e.g. watching a video with no input) flips the verdict on its own:
+
+  - screen lock state        (deliberate "I'm leaving")
+  - screensaver activity     (idle long enough that the saver kicked in)
+  - input idle time          (seconds since last mouse / keyboard event)
+  - active Focus mode         (reported as context; only counts as "away"
+                               for the modes you opt in via --away-focus)
+
+This script carries inline PEP 723 metadata, so run it with uv — which reads
+that metadata and provisions an ephemeral environment with the one dependency
+(PyObjC's Quartz, needed for reliable lock + idle detection):
+
+  uv run scripts/presence.py                        # JSON verdict
+  uv run scripts/presence.py --idle 180             # >=180s idle counts as away (default 120)
+  uv run scripts/presence.py --away-focus Sleep,Personal   # these Focus modes mean "away"
+  ./scripts/presence.py                             # if chmod +x'd (uses the uv shebang)
+
+Exit code: 0 if present, 1 if away. Handy for launchd / shell guards.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+from Quartz import (
+    CGEventSourceSecondsSinceLastEventType,
+    CGSessionCopyCurrentDictionary,
+    kCGAnyInputEventType,
+    kCGEventSourceStateHIDSystemState,
+)
+
+
+def idle_seconds() -> float:
+    """Seconds since the last keyboard / mouse event."""
+    return float(
+        CGEventSourceSecondsSinceLastEventType(
+            kCGEventSourceStateHIDSystemState, kCGAnyInputEventType
+        )
+    )
+
+
+def screen_locked() -> bool:
+    """True if the lock screen is showing."""
+    session = CGSessionCopyCurrentDictionary() or {}
+    return bool(session.get("CGSSessionScreenIsLocked", False))
+
+
+def screensaver_running() -> bool:
+    """True if a screensaver process is currently engaged."""
+    for args in (["pgrep", "-x", "ScreenSaverEngine"], ["pgrep", "-f", "legacyScreenSaver"]):
+        try:
+            if subprocess.run(args, capture_output=True).returncode == 0:
+                return True
+        except OSError:
+            continue  # this probe failed; still try the other matcher
+    return False
+
+
+def focus_mode() -> str | None:
+    """Name of the active macOS Focus mode, or None if none / undetermined.
+
+    There is no public API for Focus state, so this reads the undocumented
+    Do Not Disturb database. It is best-effort and may break on a major
+    macOS release; every failure path simply returns None.
+    """
+    base = os.path.expanduser("~/Library/DoNotDisturb/DB")
+    assertions_path = os.path.join(base, "Assertions.json")
+    config_path = os.path.join(base, "ModeConfigurations.json")
+
+    # Which mode is currently asserted? Absent records == no active Focus.
+    try:
+        with open(assertions_path) as f:
+            records = json.load(f)["data"][0]["storeAssertionRecords"]
+        if not records:
+            return None
+        mode_id = records[0]["assertionDetails"]["assertionDetailsModeIdentifier"]
+    except (OSError, KeyError, IndexError, ValueError):
+        return None
+
+    # Resolve the human-readable name; fall back to the raw identifier.
+    try:
+        with open(config_path) as f:
+            configs = json.load(f)["data"][0]["modeConfigurations"]
+        return configs[mode_id]["mode"]["name"]
+    except (OSError, KeyError, IndexError, ValueError):
+        return mode_id  # e.g. "com.apple.focus.work"
+
+
+def assess(idle_threshold: float, away_focus: tuple[str, ...] = ()) -> dict:
+    locked = screen_locked()
+    saver = screensaver_running()
+    idle = idle_seconds()
+    focus = focus_mode()
+
+    away_focus_norm = {f.strip().lower() for f in away_focus if f.strip()}
+    focus_is_away = focus is not None and focus.lower() in away_focus_norm
+
+    # Order matters: strongest, most deliberate signals win first.
+    if locked:
+        status, reason = "away", "screen is locked"
+    elif saver:
+        status, reason = "away", "screensaver is active"
+    elif focus_is_away:
+        status, reason = "away", f"focus mode '{focus}' is configured as away"
+    elif idle >= idle_threshold:
+        status, reason = "away", f"idle {idle:.0f}s (>= {idle_threshold:.0f}s)"
+    else:
+        status, reason = "present", f"active within last {idle:.0f}s"
+
+    return {
+        "status": status,
+        "reason": reason,
+        "signals": {
+            "screen_locked": locked,
+            "screensaver_running": saver,
+            "idle_seconds": round(idle, 1),
+            "focus_mode": focus,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Detect macOS presence.")
+    parser.add_argument(
+        "--idle", type=float, default=120.0,
+        help="Idle seconds before counting as away (default: 120)",
+    )
+    parser.add_argument(
+        "--away-focus", default="",
+        help="Comma-separated Focus mode names that should count as away "
+             "(e.g. 'Sleep,Personal'). Matches the human name or raw identifier.",
+    )
+    args = parser.parse_args()
+
+    away_focus = tuple(args.away_focus.split(",")) if args.away_focus else ()
+    result = assess(args.idle, away_focus)
+    print(json.dumps(result))
+    return 0 if result["status"] == "present" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Moves the presence-detector skill from briandconnelly/skills into this marketplace as a skills-only plugin.

- `plugins/presence-detector/` with Claude Code and Codex manifests, README, and the skill (SKILL.md + `scripts/presence.py`)
- Registered in `.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`, and the README table (alphabetical)
- Validated with plugin-dev plugin-validator and prek; script smoke-tested from its new location

The source copy is being removed from briandconnelly/skills in a companion commit.

🤖 Generated with Claude Code