### PR TITLE
chore(cc-plugin-codex): bump to 0.5.0

### DIFF
--- a/plugins/cc-plugin-codex/.codex-plugin/plugin.json
+++ b/plugins/cc-plugin-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-plugin-codex",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Call Claude Code from Codex for bounded, independent code review and second opinions",
   "author": {
     "name": "Brian Connelly",

--- a/plugins/cc-plugin-codex/.mcp.json
+++ b/plugins/cc-plugin-codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/briandconnelly/cc-plugin-codex.git@v0.4.0",
+        "git+https://github.com/briandconnelly/cc-plugin-codex.git@v0.5.0",
         "cc-plugin-codex-mcp"
       ],
       "env_vars": [


### PR DESCRIPTION
Updates cc-plugin-codex to upstream v0.5.0.

- `.mcp.json`: git pin `@v0.4.0` → `@v0.5.0`
- `.codex-plugin/plugin.json`: `version` 0.4.0 → 0.5.0

🤖 Generated with Claude Code