### PR TITLE
chore(cwms): bump to 0.5.0

### DIFF
--- a/plugins/cwms/.claude-plugin/plugin.json
+++ b/plugins/cwms/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cwms",
   "description": "MCP server for querying U.S. Army Corps of Engineers water data via the CWMS Data API",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "Brian Connelly"
   },
@@ -11,7 +11,7 @@
   "mcpServers": {
     "cwms-tools": {
       "command": "uvx",
-      "args": ["cwms-tools==0.4.0", "mcp", "serve"]
+      "args": ["cwms-tools==0.5.0", "mcp", "serve"]
     }
   }
 }

--- a/plugins/cwms/.codex-plugin/plugin.json
+++ b/plugins/cwms/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cwms",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "MCP server for querying U.S. Army Corps of Engineers water data via the CWMS Data API",
   "author": {
     "name": "Brian Connelly",

--- a/plugins/cwms/.mcp.json
+++ b/plugins/cwms/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "cwms-tools": {
       "command": "uvx",
-      "args": ["cwms-tools==0.4.0", "mcp", "serve"]
+      "args": ["cwms-tools==0.5.0", "mcp", "serve"]
     }
   }
 }


### PR DESCRIPTION
Updates cwms plugin to cwms-tools v0.5.0 (latest on PyPI).

- `.mcp.json` and `.claude-plugin/plugin.json`: `cwms-tools==0.4.0` → `==0.5.0`
- `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`: `version` 0.4.0 → 0.5.0

This commit was originally made directly on `main` (unpushed); moved to its own branch.

🤖 Generated with Claude Code