### PR TITLE
feat(codex-in-claude): add marketplace and README entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,6 +8,15 @@
   },
   "plugins": [
     {
+      "name": "codex-in-claude",
+      "source": {
+        "source": "github",
+        "repo": "briandconnelly/codex-in-claude"
+      },
+      "description": "MCP server for calling OpenAI Codex from Claude Code for second opinions, code review, and delegated coding tasks",
+      "category": "utilities"
+    },
+    {
       "name": "cwms",
       "source": "./plugins/cwms",
       "description": "MCP server for querying U.S. Army Corps of Engineers water data via the CWMS Data API",

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ In Codex, install plugins from the `briandconnelly-plugins` marketplace after ad
 | **Plugin** | **Description** |
 | --- | --- |
 | [cc-plugin-codex](plugins/cc-plugin-codex/) | (Codex only) Call Claude Code from Codex for bounded, independent code review and second opinions |
+| [codex-in-claude](https://github.com/briandconnelly/codex-in-claude) | MCP server for calling OpenAI Codex from Claude Code for second opinions, code review, and delegated coding tasks |
 | [cwms](plugins/cwms/) | MCP server for querying U.S. Army Corps of Engineers water data via the CWMS Data API |
 | [ipinfo](plugins/ipinfo/) | MCP server for getting IP address details, location, and network information via ipinfo.io |
 | [orb-cloud](plugins/orb-cloud/) | MCP server for managing Orb Cloud organizations and devices |


### PR DESCRIPTION
Adds the externally-hosted [codex-in-claude](https://github.com/briandconnelly/codex-in-claude) Claude Code plugin to the marketplace and README.

- `.claude-plugin/marketplace.json`: github source entry
- `README.md`: table row linking to the external repo

Skipped `.agents/plugins/marketplace.json` (Codex marketplace) since this is a Claude Code plugin.

🤖 Generated with Claude Code