### PR TITLE
feat(hermes-tweet): add plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -29,6 +29,18 @@
       "category": "Utilities"
     },
     {
+      "name": "hermes-tweet",
+      "source": {
+        "source": "local",
+        "path": "./plugins/hermes-tweet"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Utilities"
+    },
+    {
       "name": "ipinfo",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,6 +23,12 @@
       "category": "utilities"
     },
     {
+      "name": "hermes-tweet",
+      "source": "./plugins/hermes-tweet",
+      "description": "Native Hermes Agent X/Twitter plugin guidance for Xquik reads and approval-gated actions",
+      "category": "utilities"
+    },
+    {
       "name": "ipinfo",
       "source": "./plugins/ipinfo",
       "description": "MCP server for getting IP address details, location, and network information via ipinfo.io",

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ In Codex, install plugins from the `briandconnelly-plugins` marketplace after ad
 | [claude-in-codex](plugins/claude-in-codex/) | (Codex only) Call Claude Code from Codex for bounded, independent code review and second opinions |
 | [codex-in-claude](https://github.com/briandconnelly/codex-in-claude) | MCP server for calling OpenAI Codex from Claude Code for second opinions, code review, and delegated coding tasks |
 | [cwms](plugins/cwms/) | MCP server for querying U.S. Army Corps of Engineers water data via the CWMS Data API |
+| [hermes-tweet](plugins/hermes-tweet/) | Native Hermes Agent X/Twitter plugin guidance for Xquik reads and approval-gated actions |
 | [ipinfo](plugins/ipinfo/) | MCP server for getting IP address details, location, and network information via ipinfo.io |
 | [orb-cloud](plugins/orb-cloud/) | MCP server for managing Orb Cloud organizations and devices |
 | [orbnet](plugins/orbnet/) | MCP server for monitoring internet quality via Orb Local API |

--- a/plugins/hermes-tweet/.claude-plugin/plugin.json
+++ b/plugins/hermes-tweet/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "hermes-tweet",
+  "description": "Native Hermes Agent X/Twitter plugin guidance for Xquik reads and approval-gated actions",
+  "version": "0.1.6",
+  "author": {
+    "name": "Xquik"
+  },
+  "repository": "https://github.com/Xquik-dev/hermes-tweet",
+  "license": "MIT",
+  "keywords": [
+    "hermes-agent",
+    "hermes-plugin",
+    "xquik",
+    "twitter",
+    "x",
+    "social-media",
+    "automation"
+  ],
+  "skills": [
+    "./skills/hermes-tweet"
+  ]
+}

--- a/plugins/hermes-tweet/.codex-plugin/plugin.json
+++ b/plugins/hermes-tweet/.codex-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "hermes-tweet",
+  "version": "0.1.6",
+  "description": "Native Hermes Agent X/Twitter plugin guidance for Xquik reads and approval-gated actions",
+  "author": {
+    "name": "Xquik",
+    "url": "https://github.com/Xquik-dev"
+  },
+  "repository": "https://github.com/Xquik-dev/hermes-tweet",
+  "license": "MIT",
+  "keywords": [
+    "hermes-agent",
+    "hermes-plugin",
+    "xquik",
+    "twitter",
+    "x",
+    "social-media",
+    "automation"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Hermes Tweet",
+    "shortDescription": "Use Hermes Agent for X/Twitter reads and gated actions.",
+    "longDescription": "Hermes Tweet helps agents install, configure, and operate the native Hermes Agent X/Twitter plugin. Use it to route X/Twitter research, public reads, and user-approved account actions through Hermes Tweet while keeping credentials in the Hermes runtime environment.",
+    "developerName": "Xquik",
+    "category": "Utilities",
+    "capabilities": [
+      "Skills"
+    ],
+    "defaultPrompt": [
+      "Use Hermes Tweet to plan a Hermes Agent X/Twitter research workflow.",
+      "Use Hermes Tweet to troubleshoot plugin installation and tool gating.",
+      "Use Hermes Tweet to prepare an approval-gated X/Twitter action."
+    ]
+  }
+}

--- a/plugins/hermes-tweet/skills/hermes-tweet/SKILL.md
+++ b/plugins/hermes-tweet/skills/hermes-tweet/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: hermes-tweet
+description: >-
+  Use when the user asks to install, configure, test, or operate Hermes Tweet, the native Hermes Agent X/Twitter plugin for Xquik read workflows and approval-gated actions.
+user-invocable: true
+argument-hint: "[Hermes Tweet task or X/Twitter workflow]"
+---
+
+You help users install, configure, test, and operate Hermes Tweet.
+Hermes Tweet is a native Hermes Agent plugin for X/Twitter work through Xquik.
+Do not treat it as a generic API wrapper or direct HTTP fallback.
+
+## Source Truth
+- Hermes Tweet README: `https://github.com/Xquik-dev/hermes-tweet#readme`
+- PyPI package: `https://pypi.org/project/hermes-tweet/`
+- Hermes plugin guide: `https://github.com/NousResearch/hermes-agent/blob/main/website/docs/guides/build-a-hermes-plugin.md`
+- Hermes plugins guide: `https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/plugins.md`
+
+## Workflow
+1. Confirm Hermes Tweet is installed and enabled in the Hermes runtime.
+2. Use `tweet_explore` first when the user asks for a capability or route.
+3. Use `tweet_read` only for catalog-listed read-only endpoints.
+4. Use `tweet_action` only for write-capable or private workflows after explicit user approval.
+5. Keep secrets in the Hermes runtime environment.
+
+## Decision Rules
+- If the user asks what Hermes Tweet can do, use `tweet_explore`.
+- If the endpoint is read-only, use `tweet_read`.
+- If the endpoint writes or changes account state, use `tweet_action` only after approval.
+- If `tweet_read` is unavailable, ask the user to configure `XQUIK_API_KEY` in the Hermes runtime environment.
+- If `tweet_action` is unavailable, explain that actions require `HERMES_TWEET_ENABLE_ACTIONS=true`.
+- If Hermes lists the plugin as `not enabled`, tell the user to run `hermes plugins enable hermes-tweet` or reinstall with `--enable`.
+- If the user uses Hermes Desktop with a remote gateway profile, install and configure Hermes Tweet on the remote Hermes host where plugin code executes.
+
+## Guardrails
+- Never ask for API keys, passwords, cookies, signing keys, or TOTP secrets.
+- Never pass credentials in tool arguments.
+- Never invent endpoints, fields, pricing, limits, or capabilities.
+- Do not create direct HTTP fallbacks.
+- Use only catalog-listed `/api/v1/...` paths.
+- Summarize side effects before any account-changing action.
+
+## Install Checks
+Use these checks when the user asks for runtime troubleshooting:
+
+```bash
+hermes plugins install Xquik-dev/hermes-tweet --enable
+hermes plugins list
+hermes tools list
+```
+
+For PyPI installs:
+
+```bash
+uv pip install --python ~/.hermes/hermes-agent/venv/bin/python hermes-tweet
+hermes plugins enable hermes-tweet
+```
+
+Expected behavior:
+- `tweet_explore` can appear without `XQUIK_API_KEY`.
+- `tweet_read` requires `XQUIK_API_KEY`.
+- `tweet_action` requires `HERMES_TWEET_ENABLE_ACTIONS=true`.
+- Third-party Hermes plugins must be enabled before tools run.


### PR DESCRIPTION
## Summary
- add a Hermes Tweet plugin entry for Claude Code and Codex
- include a focused skill for installing, configuring, and operating Hermes Tweet in Hermes Agent
- register marketplace metadata for the local plugin catalog

## Notes
- The target repository does not declare a repository license, so this PR only adds Hermes Tweet's own MIT license metadata in the plugin manifests.
- Hermes Tweet targets the native Hermes Agent plugin runtime and keeps account-changing actions behind explicit tool gates.
- Current Hermes plugin docs and source APIs were checked before adding the listing.

## Validation
- jq . .claude-plugin/marketplace.json .agents/plugins/marketplace.json plugins/hermes-tweet/.claude-plugin/plugin.json plugins/hermes-tweet/.codex-plugin/plugin.json
- git diff --check
- uvx prek run --all-files
