### PR TITLE
refactor(tempest): separate binding rules from context in weather-report skill

### DIFF
--- a/plugins/tempest/skills/weather-report/SKILL.md
+++ b/plugins/tempest/skills/weather-report/SKILL.md
@@ -89,7 +89,8 @@ When producing a general briefing or when no specific question is asked:
 
 ## Alerts & Anomalies
 
-Proactively flag these when present in the data:
+Scan only the data already retrieved for the question — do not fetch additional data solely to look for anomalies.
+Proactively flag these when present:
 
 - Rapid barometric pressure drops (potential storm approaching)
 - Lightning activity or strikes detected

--- a/plugins/tempest/skills/weather-report/SKILL.md
+++ b/plugins/tempest/skills/weather-report/SKILL.md
@@ -17,6 +17,7 @@ allowed-tools:
   - mcp__plugin_tempest_mcp-server-tempest__tempest_get_observation
   - mcp__plugin_tempest_mcp-server-tempest__tempest_get_forecast
   - mcp__plugin_tempest_mcp-server-tempest__tempest_get_station_details
+  - mcp__plugin_tempest_mcp-server-tempest__tempest_get_capabilities
   - ReadMcpResourceTool
   - WebSearch
 ---
@@ -35,20 +36,28 @@ Use WebSearch only to supplement station data with seasonal norms, historical re
 
 2. **Fetch only what the question requires**:
    - Current conditions only → `tempest_get_observation` alone is sufficient.
-   - Forecast or trend questions → also call `tempest_get_forecast`. Use `hours` and `days` to set depth, but note that summary (default) mode silently caps output at 6 hourly and 2 daily entries; pass `detailed=true` to lift the cap. Check the response's `truncated` flag and `truncation_hint` (alongside `requested_*` / `returned_*`) to detect clipping before telling the user a range is complete.
+   - Forecast or trend questions → also call `tempest_get_forecast`. Use `hours` and `days` to set depth. Summary (default) mode caps output at 6 hourly and 2 daily entries; pass `detailed=true` to lift the cap.
+     - **Before telling the user a range is complete, check the response's `truncated` flag and `truncation_hint`** (alongside `requested_*` / `returned_*`) to detect clipping.
    - Derived/comfort metrics (WBGT, delta-T, wet bulb, heat index, air density, feels-like) → pass `detailed=true` to `tempest_get_observation` or `tempest_get_forecast` (only those two accept the parameter). Concise (default) responses omit null-valued fields to save tokens, so these metrics are often absent unless you request detail.
 
 3. **Check data quality before answering** (see Data Quality below).
 
 4. **Classify the question and apply the appropriate section below** — most questions fit one or two sections. Don't run all analyses for every question.
 
-5. **Respond** in plain language, using the station's configured units. If the user requests a different unit system, convert before responding.
+5. **Respond** following the Output rules below.
+
+## Output
+
+These apply to every response, whichever analysis sections you used:
+
+- Respond in plain language. Translate raw fields into described values (e.g. `wind_avg: 3.6` → "light breeze at 8 mph"), not raw numbers alone.
+- Use the station's configured units. If the user requests a different unit system, convert before responding.
 
 ## Data Quality
 
 Before interpreting sensor values, check:
 
-- **Stale data**: Prefer `_meta.ts_retrieved` (RFC 3339 UTC — when the data was actually fetched upstream) over the observation's own timestamp. It may be omitted on some cache hits, so fall back to the observation timestamp when it is absent. `_meta.cache` tells you the source: `miss` means freshly fetched, while `memory` or `disk` means it was served from cache and may be older. If the effective data is more than 10 minutes old, note this before answering.
+- **Stale data**: **If the effective data is more than 10 minutes old, say so before answering.** To find the effective age, prefer `_meta["net.bconnelly.tempest/fetch"].ts_retrieved` (RFC 3339 UTC — when the data was actually fetched upstream) over the observation's own timestamp; it may be omitted on some cache hits, so fall back to the observation timestamp when absent. The same object's `cache` field tells you the source: `miss` means freshly fetched, while `memory` or `disk` means it was served from cache and may be older.
 - **Missing or null fields**: Concise (default) responses omit null-valued optional fields, so an absent field is not an error. Some metrics (WBGT, delta-T, air density) are only computed under certain conditions. If a metric you need is missing, re-fetch with `detailed=true`; if it is still null, skip it rather than reporting "null."
 - **Implausible values**: A temperature of −50°C or UV of 30 likely indicates a sensor fault. Note the anomaly rather than interpreting the value literally.
 - **Forecast vs. observation disagreement**: If current conditions and the forecast's current snapshot differ substantially, prefer the observation and note the discrepancy.
@@ -67,8 +76,8 @@ Act on the `code`:
 
 ## Server Capabilities
 
-The server exposes a machine-readable `tempest://capabilities` resource (read it with the MCP resource tool) summarizing the available tools, error codes, station scope, and a surface `fingerprint` — the same value that appears in every result's `_meta.fingerprint`.
-You normally don't need it, but consult it if a tool's name or behavior seems to disagree with these instructions, which usually means the server was upgraded.
+The server exposes a machine-readable `tempest://capabilities` resource (also available as the `tempest_get_capabilities` tool, for clients that surface MCP resources poorly) summarizing the available tools, error codes, station scope, and a surface `fingerprint` — the same value that appears in every result's `_meta["net.bconnelly.tempest/fetch"].fingerprint`.
+When a tool's name or behavior disagrees with these instructions, consult it — a server upgrade is the usual cause. Otherwise you don't need it.
 
 ## Weather Briefing
 
@@ -133,7 +142,7 @@ These are estimates — local topography, season, and frontal structure affect r
 - **Steady at 1020+ mb**: Fair weather likely to persist.
 - **Steady below 1000 mb**: Unsettled conditions likely to continue.
 
-When the trend is "falling" or "rising", call it out proactively.
+(Falling and rising pressure trends are on the Alerts & Anomalies proactive-flag list.)
 
 ## Gardening & Frost Guidance
 
@@ -155,7 +164,7 @@ Use `lightning_strike_count`, `lightning_strike_count_last_1hr`, `lightning_stri
 
 Check `lightning_strike_last_epoch` against the current time. Strikes more than a few hours old are historical. Use 1-hour and 3-hour counts to judge whether activity is ongoing.
 
-When lightning is detected, flag it proactively even if the user didn't ask.
+(Detected lightning is on the Alerts & Anomalies proactive-flag list.)
 
 ## Precipitation Type Inference
 

--- a/plugins/tempest/skills/weather-report/SKILL.md
+++ b/plugins/tempest/skills/weather-report/SKILL.md
@@ -52,7 +52,11 @@ Use WebSearch only to supplement station data with seasonal norms, historical re
 
 Before interpreting sensor values, check:
 
-- **Stale data**: Prefer `_meta.ts_retrieved` (RFC 3339 UTC — when the data was actually fetched upstream) over the observation's own timestamp. It may be omitted on some cache hits, so fall back to the observation timestamp when it is absent. `_meta.cache` tells you the source: `miss` means freshly fetched, while `memory` or `disk` means it was served from cache and may be older. If the effective data is more than 10 minutes old, note this before answering.
+- **Stale data**: Cache provenance lives in `_meta["net.bconnelly.tempest/fetch"]` as `{cache, fingerprint, ts_retrieved}`.
+  Prefer its `ts_retrieved` (RFC 3339 UTC — when the data was actually fetched upstream) over the observation's own timestamp.
+  `ts_retrieved` may be omitted on some cache hits, so fall back to the observation timestamp when it is absent.
+  The `cache` field tells you the source: `miss` means freshly fetched, while `memory` or `disk` means it was served from cache and may be older.
+  If the effective data is more than 10 minutes old, note this before answering.
 - **Missing or null fields**: Concise (default) responses omit null-valued optional fields, so an absent field is not an error. Some metrics (WBGT, delta-T, air density) are only computed under certain conditions. If a metric you need is missing, re-fetch with `detailed=true`; if it is still null, skip it rather than reporting "null."
 - **Implausible values**: A temperature of −50°C or UV of 30 likely indicates a sensor fault. Note the anomaly rather than interpreting the value literally.
 - **Forecast vs. observation disagreement**: If current conditions and the forecast's current snapshot differ substantially, prefer the observation and note the discrepancy.
@@ -71,7 +75,7 @@ Act on the `code`:
 
 ## Server Capabilities
 
-The server exposes a machine-readable `tempest://capabilities` resource (read it with the MCP resource tool) summarizing the available tools, error codes, station scope, and a surface `fingerprint` — the same value that appears in every result's `_meta.fingerprint`.
+The server exposes a machine-readable `tempest://capabilities` resource (read it with the MCP resource tool) summarizing the available tools, error codes, station scope, and a surface `fingerprint` — the same value that appears in every result's `_meta["net.bconnelly.tempest/fetch"].fingerprint`.
 You normally don't need it, but consult it if a tool's name or behavior seems to disagree with these instructions, which usually means the server was upgraded.
 
 ## Weather Briefing

--- a/plugins/tempest/skills/weather-report/SKILL.md
+++ b/plugins/tempest/skills/weather-report/SKILL.md
@@ -54,7 +54,7 @@ Use WebSearch only to supplement station data with seasonal norms, historical re
 These apply to every response, whichever analysis sections you used:
 
 - Respond in plain language.
-  Translate raw fields into described values (e.g. `wind_avg: 3.6` → "light breeze at 8 mph"), not raw numbers alone.
+  Translate raw fields into described values in the station's configured units (e.g. `wind_avg: 3.6` → "light breeze at 8 mph" on a station configured for mph), not raw numbers alone.
 - Use the station's configured units.
   If the user requests a different unit system, convert before responding.
 - For casual questions like "do I need a jacket?" or "is it good for a run?", give a direct, conversational answer first, back it up with the relevant data points, and add practical advice when it changes what the user should do (gear, timing, route).
@@ -66,7 +66,7 @@ Before interpreting sensor values, check:
 - **Stale data**: **If the effective data is more than 10 minutes old, say so before answering.**
   To find the effective age, prefer `ts_retrieved` in `_meta["net.bconnelly.tempest/fetch"]` (RFC 3339 UTC — when the data was actually fetched upstream) over the observation's own timestamp.
   `ts_retrieved` may be omitted on some cache hits, so fall back to the observation timestamp when it is absent.
-  The `cache` field in the same `_meta` block tells you the source: `miss` means freshly fetched, while `memory` or `disk` means it was served from cache and may be older.
+  `_meta["net.bconnelly.tempest/fetch"].cache` tells you the source: `miss` means freshly fetched, while `memory` or `disk` means it was served from cache and may be older.
 - **Missing or null fields**: Concise (default) responses omit null-valued optional fields, so an absent field is not an error.
   Some metrics (WBGT, delta-T, air density) are only computed under certain conditions.
   If a metric you need is missing, re-fetch with `detailed=true`; if it is still null, skip it rather than reporting "null."
@@ -110,7 +110,7 @@ When producing a general briefing or when no specific question is asked:
 Scan only the data already retrieved for the question — do not fetch additional data solely to look for anomalies.
 Proactively flag these when present:
 
-- Barometric pressure trending falling or rising (potential storm approaching)
+- Barometric pressure trending falling (potential storm approaching) or rising (clearing likely)
 - Lightning activity or strikes detected
 - High UV index (6+)
 - Extreme temperatures for the season (use WebSearch to retrieve local historical norms if needed to confirm the deviation is significant)

--- a/plugins/tempest/skills/weather-report/SKILL.md
+++ b/plugins/tempest/skills/weather-report/SKILL.md
@@ -102,7 +102,7 @@ When producing a general briefing or when no specific question is asked:
 Scan only the data already retrieved for the question — do not fetch additional data solely to look for anomalies.
 Proactively flag these when present:
 
-- Rapid barometric pressure drops (potential storm approaching)
+- Falling pressure trend (potential storm approaching)
 - Lightning activity or strikes detected
 - High UV index (6+)
 - Extreme temperatures for the season (use WebSearch to retrieve local historical norms if needed to confirm the deviation is significant)
@@ -117,7 +117,7 @@ When the user asks about trends or changes:
 - Compare the current observation to the forecast's current snapshot to infer direction
 - Identify patterns: rising/falling pressure, temperature trends, wind shifts
 - Note rapid changes that might indicate incoming weather fronts
-- If the API doesn't provide a time-series history, note that recent trends are estimated from the current pressure trend and short-range forecast rather than measured history
+- The API provides no time-series history, so note that recent trends are estimated from the current pressure trend and short-range forecast rather than measured history
 - Describe trends in plain language with supporting data
 
 ## Comfort & Heat Stress
@@ -154,6 +154,7 @@ Present as likely outcomes, not certainties.
 - **Falling, sea-level pressure at or below 1010 mb**: Front likely approaching; conditions may deteriorate within hours.
 - **Rising**: Clearing likely; improving conditions ahead.
 - **Steady at 1020+ mb**: Fair weather likely to persist.
+- **Steady between 1000 and 1020 mb**: No strong pressure signal; rely on the forecast.
 - **Steady below 1000 mb**: Unsettled conditions likely to continue.
 
 When the trend is "falling" or "rising", call it out proactively.

--- a/plugins/tempest/skills/weather-report/SKILL.md
+++ b/plugins/tempest/skills/weather-report/SKILL.md
@@ -57,7 +57,7 @@ These apply to every response, whichever analysis sections you used:
 
 Before interpreting sensor values, check:
 
-- **Stale data**: **If the effective data is more than 10 minutes old, say so before answering.** To find the effective age, prefer `_meta["net.bconnelly.tempest/fetch"].ts_retrieved` (RFC 3339 UTC — when the data was actually fetched upstream) over the observation's own timestamp; it may be omitted on some cache hits, so fall back to the observation timestamp when absent. The same object's `cache` field tells you the source: `miss` means freshly fetched, while `memory` or `disk` means it was served from cache and may be older.
+- **Stale data**: **If the effective data is more than 10 minutes old, say so before answering.** To find the effective age, prefer `_meta["net.bconnelly.tempest/fetch"].ts_retrieved` (RFC 3339 UTC — when the data was actually fetched upstream) over the observation's own timestamp; it may be omitted on some cache hits, so fall back to the observation timestamp when absent. The `_meta["net.bconnelly.tempest/fetch"].cache` field tells you the source: `miss` means freshly fetched, while `memory` or `disk` means it was served from cache and may be older.
 - **Missing or null fields**: Concise (default) responses omit null-valued optional fields, so an absent field is not an error. Some metrics (WBGT, delta-T, air density) are only computed under certain conditions. If a metric you need is missing, re-fetch with `detailed=true`; if it is still null, skip it rather than reporting "null."
 - **Implausible values**: A temperature of −50°C or UV of 30 likely indicates a sensor fault. Note the anomaly rather than interpreting the value literally.
 - **Forecast vs. observation disagreement**: If current conditions and the forecast's current snapshot differ substantially, prefer the observation and note the discrepancy.
@@ -92,7 +92,7 @@ When producing a general briefing or when no specific question is asked:
 
 Proactively flag these when present in the data:
 
-- Rapid barometric pressure drops (potential storm approaching)
+- Barometric pressure trending falling or rising, especially rapid drops (potential storm approaching)
 - Lightning activity or strikes detected
 - High UV index (6+)
 - Extreme temperatures for the season (use WebSearch to retrieve local historical norms if needed to confirm the deviation is significant)

--- a/plugins/tempest/skills/weather-report/SKILL.md
+++ b/plugins/tempest/skills/weather-report/SKILL.md
@@ -129,15 +129,17 @@ Only call out feels-like when it meaningfully differs from actual air temperatur
 
 ## Pressure-Based Forecasting
 
-Go beyond reporting the `pressure_trend` value. Use pressure changes to give short-term guidance.
-All thresholds are in mb (≡ hPa). If the station reports in inHg, multiply by 33.864.
+Go beyond reporting the `pressure_trend` value (`falling`, `steady`, or `rising`).
+The server exposes no pressure history, so a rate of change cannot be computed — interpret the categorical trend together with the current sea-level pressure and the short-range forecast.
+Pressure values below are in mb (≡ hPa).
+If the station reports in inHg, multiply by 33.864.
 
-These are estimates — local topography, season, and frontal structure affect reliability. Present as likely outcomes, not certainties.
+These are estimates — local topography, season, and frontal structure affect reliability.
+Present as likely outcomes, not certainties.
 
-- **Falling 1–2 mb/hr**: Conditions likely changing; rain or wind probable within 6–12 hours.
-- **Falling 2–3 mb/hr**: Front approaching; conditions likely deteriorating within a few hours.
-- **Falling 3+ mb/hr**: Rapid deterioration; storm likely arriving soon.
-- **Rising after a drop**: Clearing likely; improving conditions ahead.
+- **Falling, sea-level pressure above 1010 mb**: Conditions likely changing; check the forecast for rain or wind in the next 6–12 hours and lead with it.
+- **Falling, sea-level pressure at or below 1010 mb**: Front likely approaching; conditions may deteriorate within hours.
+- **Rising**: Clearing likely; improving conditions ahead.
 - **Steady at 1020+ mb**: Fair weather likely to persist.
 - **Steady below 1000 mb**: Unsettled conditions likely to continue.
 

--- a/plugins/tempest/skills/weather-report/SKILL.md
+++ b/plugins/tempest/skills/weather-report/SKILL.md
@@ -35,7 +35,11 @@ Use WebSearch only to supplement station data with seasonal norms, historical re
 
 2. **Fetch only what the question requires**:
    - Current conditions only → `tempest_get_observation` alone is sufficient.
-   - Forecast or trend questions → also call `tempest_get_forecast`. Use `hours` and `days` to set depth, but note that summary (default) mode silently caps output at 6 hourly and 2 daily entries; pass `detailed=true` to lift the cap. Check the response's `truncated` flag and `truncation_hint` (alongside `requested_*` / `returned_*`) to detect clipping before telling the user a range is complete.
+   - Forecast or trend questions → also call `tempest_get_forecast`.
+     Pass explicit `hours` / `days` to set depth — they are honored in both summary and detailed modes.
+     When `hours` / `days` are omitted, the response defaults to 6 hourly and 2 daily entries.
+     Use `detailed=true` only when you need full field density (it also returns every available entry when `hours` / `days` are omitted), not as the way to get more entries.
+     Check the response's `truncated` flag and `truncation_hint` (alongside `requested_*` / `returned_*`) to detect an upstream shortfall before telling the user a range is complete.
    - Derived/comfort metrics (WBGT, delta-T, wet bulb, heat index, air density, feels-like) → pass `detailed=true` to `tempest_get_observation` or `tempest_get_forecast` (only those two accept the parameter). Concise (default) responses omit null-valued fields to save tokens, so these metrics are often absent unless you request detail.
 
 3. **Check data quality before answering** (see Data Quality below).

--- a/plugins/tempest/skills/weather-report/SKILL.md
+++ b/plugins/tempest/skills/weather-report/SKILL.md
@@ -38,7 +38,8 @@ Use WebSearch only to supplement station data with seasonal norms, historical re
      When `hours` / `days` are omitted, the response defaults to 6 hourly and 2 daily entries.
      Use `detailed=true` only when you need full field density (it also returns every available entry when `hours` / `days` are omitted), not as the way to get more entries.
      Check the response's `truncated` flag and `truncation_hint` (alongside `requested_*` / `returned_*`) to detect an upstream shortfall before telling the user a range is complete.
-   - Derived/comfort metrics (WBGT, delta-T, wet bulb, heat index, air density, feels-like) → pass `detailed=true` to `tempest_get_observation` or `tempest_get_forecast` (only those two accept the parameter). Concise (default) responses omit null-valued fields to save tokens, so these metrics are often absent unless you request detail.
+   - Derived/comfort metrics (WBGT, delta-T, wet bulb, heat index, air density, feels-like) → pass `detailed=true` to `tempest_get_observation` or `tempest_get_forecast` (only those two accept the parameter).
+     Concise (default) responses omit null-valued fields to save tokens, so these metrics are often absent unless you request detail.
 
 3. **Check data quality before answering** (see Data Quality below).
 
@@ -129,7 +130,8 @@ Interpret derived comfort metrics rather than listing raw numbers:
 
 ## Feels Like Temperature
 
-The station reports `feels_like`, `wind_chill`, and `heat_index`. Choose the right metric:
+The station reports `feels_like`, `wind_chill`, and `heat_index`.
+Choose the right metric:
 
 - **Wind chill** is meaningful only when temperature is below 10°C (50°F) and wind is above 3 mph. Otherwise it equals air temperature.
 - **Heat index** is meaningful only when temperature is above 27°C (80°F) and humidity is above 40%. Otherwise it equals air temperature.
@@ -160,7 +162,8 @@ When the trend is "falling" or "rising", call it out proactively.
 
 Include the guidance below when the user asks about gardening, plants, or yard work, or when a briefing surfaces frost risk, spray-relevant conditions, or significant recent or forecast rain:
 
-- **Frost risk**: Flag when overnight lows are forecast at or below 2°C (36°F). Advise covering or bringing in sensitive plants.
+- **Frost risk**: Flag when overnight lows are forecast at or below 2°C (36°F).
+  Advise covering or bringing in sensitive plants.
 - **Watering guidance**: If measurable precipitation fell in the last 24 hours (`precip_accum_local_day` or `precip_accum_local_yesterday_final`) or rain is forecast at 50%+ probability in the next 24 hours, suggest skipping manual watering.
 - **Spray safety**: Delta-T between 2–8°C and wind below 10 mph are ideal for pesticide/herbicide application.
   Below 2°C: droplets won't evaporate properly.
@@ -173,7 +176,8 @@ Include the guidance below when the user asks about gardening, plants, or yard w
 Use `lightning_strike_count`, `lightning_strike_count_last_1hr`, `lightning_strike_count_last_3hr`, `lightning_strike_last_distance`, and `lightning_strike_last_epoch`:
 
 - **No risk**: Zero strikes in the last 3 hours.
-- **Distant activity**: Strikes detected but >30 km away. Worth monitoring.
+- **Distant activity**: Strikes detected but >30 km away.
+  Worth monitoring.
 - **Approaching threat**: Strikes 15–30 km away, especially if count is increasing or distance decreasing.
   Advise caution outdoors.
 - **Immediate danger**: Strikes closer than 15 km.
@@ -187,7 +191,8 @@ When lightning is detected, flag it proactively even if the user didn't ask.
 
 ## Precipitation Type Inference
 
-The station reports precipitation rate but not type. Infer from wet bulb temperature.
+The station reports precipitation rate but not type.
+Infer from wet bulb temperature.
 These thresholds are estimates; vertical temperature structure and local elevation can shift the boundaries.
 
 - **Wet bulb below −1°C (30°F)**: Almost certainly snow.

--- a/plugins/tempest/skills/weather-report/SKILL.md
+++ b/plugins/tempest/skills/weather-report/SKILL.md
@@ -7,9 +7,7 @@ description: >-
   clothing/comfort questions, gardening or frost risk, spray safety, lightning,
   trail drying, solar conditions, pressure changes, and activity suitability
   such as running or drone flying. Scoped to the user's own Tempest station;
-  not a general or regional weather service. Use WebSearch only when seasonal
-  norms, regional context, or historical comparison are needed beyond station
-  data.
+  not a general or regional weather service.
 user-invocable: true
 argument-hint: "[question or topic]"
 allowed-tools:
@@ -21,7 +19,7 @@ allowed-tools:
   - WebSearch
 ---
 
-You are a weather analyst with access to a WeatherFlow Tempest personal weather station.
+Answer weather questions using data from the user's WeatherFlow Tempest personal weather station.
 Use the MCP tools to retrieve real-time observations, forecasts, and station metadata.
 Use WebSearch only to supplement station data with seasonal norms, historical records, or regional context — not as a primary source.
 
@@ -46,7 +44,9 @@ Use WebSearch only to supplement station data with seasonal norms, historical re
 
 4. **Classify the question and apply the appropriate section below** — most questions fit one or two sections. Don't run all analyses for every question.
 
-5. **Respond** in plain language, using the station's configured units. If the user requests a different unit system, convert before responding.
+5. **Respond** in plain language, using the station's configured units.
+   If the user requests a different unit system, convert before responding.
+   For casual questions like "do I need a jacket?" or "is it good for a run?", give a direct, conversational answer first, back it up with the relevant data points, and add practical advice when it changes what the user should do (gear, timing, route).
 
 ## Data Quality
 
@@ -214,11 +214,3 @@ Mention air density only when the user asks about sports performance, drone flyi
 - **Below 200 W/m²**: Very low — heavy overcast, rain, or near sunrise/sunset.
 
 Mention solar radiation when the user asks about solar energy, outdoor photography, or UV exposure context.
-
-## Natural Language Q&A
-
-For casual questions like "do I need a jacket?" or "is it good for a run?":
-
-- Give a direct, conversational answer first
-- Back it up with the relevant data points
-- Include practical advice when appropriate

--- a/plugins/tempest/skills/weather-report/SKILL.md
+++ b/plugins/tempest/skills/weather-report/SKILL.md
@@ -152,7 +152,10 @@ When conditions are relevant, include gardening advice:
 
 - **Frost risk**: Flag when overnight lows are forecast at or below 2°C (36°F). Advise covering or bringing in sensitive plants.
 - **Watering guidance**: If measurable precipitation fell in the last 24 hours (`precip_accum_local_day` or `precip_accum_local_yesterday_final`) or rain is forecast at 50%+ probability in the next 24 hours, suggest skipping manual watering.
-- **Spray safety**: Delta-T between 2–8°C and wind below 10 mph are ideal for pesticide/herbicide application. Below 2°C: droplets won't evaporate properly. Above 10°C: too much evaporation and drift risk.
+- **Spray safety**: Delta-T between 2–8°C and wind below 10 mph are ideal for pesticide/herbicide application.
+  Below 2°C: droplets won't evaporate properly.
+  8–10°C: marginal — evaporation losses increase, so prefer the cooler parts of the day.
+  Above 10°C: too much evaporation and drift risk.
 - **UV stress**: UV index 6+ is strong enough to stress transplants and light-skinned fruit.
 
 ## Lightning Risk Assessment
@@ -161,8 +164,10 @@ Use `lightning_strike_count`, `lightning_strike_count_last_1hr`, `lightning_stri
 
 - **No risk**: Zero strikes in the last 3 hours.
 - **Distant activity**: Strikes detected but >30 km away. Worth monitoring.
-- **Approaching threat**: Strikes within 15–30 km, especially if count is increasing or distance decreasing. Advise caution outdoors.
-- **Immediate danger**: Strikes within 15 km. Advise seeking shelter immediately — avoid open areas, water, tall isolated objects, and metal structures.
+- **Approaching threat**: Strikes 15–30 km away, especially if count is increasing or distance decreasing.
+  Advise caution outdoors.
+- **Immediate danger**: Strikes closer than 15 km.
+  Advise seeking shelter immediately — avoid open areas, water, tall isolated objects, and metal structures.
 
 Check `lightning_strike_last_epoch` against the current time. Strikes more than a few hours old are historical. Use 1-hour and 3-hour counts to judge whether activity is ongoing.
 
@@ -194,7 +199,7 @@ Useful for outdoor projects, trail conditions, or post-rain timing:
 `air_density` in kg/m³; sea-level standard is ~1.225 kg/m³:
 
 - **Below 1.15 kg/m³**: Thin air — reduced engine performance, less drone lift, balls travel farther.
-- **1.15–1.25 kg/m³**: Normal range.
+- **1.15–1.30 kg/m³**: Normal range.
 - **Above 1.30 kg/m³**: Dense air — better engine performance, more drone lift, balls travel shorter.
 
 Mention air density only when the user asks about sports performance, drone flying, or engine/vehicle performance, or when the value is notably outside normal range.

--- a/plugins/tempest/skills/weather-report/SKILL.md
+++ b/plugins/tempest/skills/weather-report/SKILL.md
@@ -42,7 +42,8 @@ Use WebSearch only to supplement station data with seasonal norms, historical re
 
 3. **Check data quality before answering** (see Data Quality below).
 
-4. **Classify the question and apply the appropriate section below** — most questions fit one or two sections. Don't run all analyses for every question.
+4. **Classify the question and apply the appropriate section below** — most questions fit one or two sections.
+   Don't run all analyses for every question.
 
 5. **Respond** in plain language, using the station's configured units.
    If the user requests a different unit system, convert before responding.
@@ -57,8 +58,11 @@ Before interpreting sensor values, check:
   `ts_retrieved` may be omitted on some cache hits, so fall back to the observation timestamp when it is absent.
   The `cache` field tells you the source: `miss` means freshly fetched, while `memory` or `disk` means it was served from cache and may be older.
   If the effective data is more than 10 minutes old, note this before answering.
-- **Missing or null fields**: Concise (default) responses omit null-valued optional fields, so an absent field is not an error. Some metrics (WBGT, delta-T, air density) are only computed under certain conditions. If a metric you need is missing, re-fetch with `detailed=true`; if it is still null, skip it rather than reporting "null."
-- **Implausible values**: A temperature of −50°C or UV of 30 likely indicates a sensor fault. Note the anomaly rather than interpreting the value literally.
+- **Missing or null fields**: Concise (default) responses omit null-valued optional fields, so an absent field is not an error.
+  Some metrics (WBGT, delta-T, air density) are only computed under certain conditions.
+  If a metric you need is missing, re-fetch with `detailed=true`; if it is still null, skip it rather than reporting "null."
+- **Implausible values**: A temperature of −50°C or UV of 30 likely indicates a sensor fault.
+  Note the anomaly rather than interpreting the value literally.
 - **Forecast vs. observation disagreement**: If current conditions and the forecast's current snapshot differ substantially, prefer the observation and note the discrepancy.
 
 ## Handling Tool Errors
@@ -67,11 +71,16 @@ When a tool call fails, the server returns a flat JSON error object instead of w
 Translate it into plain language for the user — never surface the raw JSON.
 Act on the `code`:
 
-- `auth_missing`, `auth_invalid`, `auth_forbidden`: the `WEATHERFLOW_API_TOKEN` is missing, wrong, or lacks access. Not retryable — tell the user to check their token configuration.
-- `invalid_argument`: a malformed argument was sent. The payload's `field` and `value` identify it; correct the call and retry.
-- `station_not_found`: the station id is unknown. Re-resolve with `tempest_get_stations` rather than retrying the same id.
-- `rate_limited`, `upstream_unavailable`: `temporary` is true. Back off briefly (honor `retry_after_ms` if present), retry once, and if it still fails tell the user the service is briefly unavailable and to try again shortly.
-- `upstream_invalid_response`, `internal_error`: not retryable. Report that the data couldn't be retrieved, and include the `request_id` if the user wants to follow up.
+- `auth_missing`, `auth_invalid`, `auth_forbidden`: the `WEATHERFLOW_API_TOKEN` is missing, wrong, or lacks access.
+  Not retryable — tell the user to check their token configuration.
+- `invalid_argument`: a malformed argument was sent.
+  The payload's `field` and `value` identify it; correct the call and retry.
+- `station_not_found`: the station id is unknown.
+  Re-resolve with `tempest_get_stations` rather than retrying the same id.
+- `rate_limited`, `upstream_unavailable`: `temporary` is true.
+  Back off briefly (honor `retry_after_ms` if present), retry once, and if it still fails tell the user the service is briefly unavailable and to try again shortly.
+- `upstream_invalid_response`, `internal_error`: not retryable.
+  Report that the data couldn't be retrieved, and include the `request_id` if the user wants to follow up.
 
 ## Server Capabilities
 
@@ -124,7 +133,8 @@ The station reports `feels_like`, `wind_chill`, and `heat_index`. Choose the rig
 
 - **Wind chill** is meaningful only when temperature is below 10°C (50°F) and wind is above 3 mph. Otherwise it equals air temperature.
 - **Heat index** is meaningful only when temperature is above 27°C (80°F) and humidity is above 40%. Otherwise it equals air temperature.
-- When neither applies, report the actual temperature. Do not call out "feels like" as a separate value.
+- When neither applies, report the actual temperature.
+  Do not call out "feels like" as a separate value.
 
 Only call out feels-like when it meaningfully differs from actual air temperature (at least 2°C / 4°F).
 
@@ -169,7 +179,9 @@ Use `lightning_strike_count`, `lightning_strike_count_last_1hr`, `lightning_stri
 - **Immediate danger**: Strikes closer than 15 km.
   Advise seeking shelter immediately — avoid open areas, water, tall isolated objects, and metal structures.
 
-Check `lightning_strike_last_epoch` against the current time. Strikes more than a few hours old are historical. Use 1-hour and 3-hour counts to judge whether activity is ongoing.
+Check `lightning_strike_last_epoch` against the current time.
+Strikes more than a few hours old are historical.
+Use 1-hour and 3-hour counts to judge whether activity is ongoing.
 
 When lightning is detected, flag it proactively even if the user didn't ask.
 
@@ -190,9 +202,12 @@ Mention inferred precipitation type only when precipitation is occurring and the
 Combine delta-T, wind, and solar radiation to assess surface drying time.
 Useful for outdoor projects, trail conditions, or post-rain timing:
 
-- **Fast drying**: Delta-T above 6°C, wind above 10 mph, solar radiation above 400 W/m². Surfaces dry within a few hours.
-- **Moderate drying**: Delta-T 3–6°C, light wind, or moderate solar. Allow half a day or more.
-- **Slow drying**: Delta-T below 3°C, calm wind, overcast (solar below 200 W/m²). Surfaces may stay wet all day; trails will be muddy.
+- **Fast drying**: Delta-T above 6°C, wind above 10 mph, solar radiation above 400 W/m².
+  Surfaces dry within a few hours.
+- **Moderate drying**: Delta-T 3–6°C, light wind, or moderate solar.
+  Allow half a day or more.
+- **Slow drying**: Delta-T below 3°C, calm wind, overcast (solar below 200 W/m²).
+  Surfaces may stay wet all day; trails will be muddy.
 
 ## Air Density & Performance
 

--- a/plugins/tempest/skills/weather-report/SKILL.md
+++ b/plugins/tempest/skills/weather-report/SKILL.md
@@ -148,7 +148,7 @@ When the trend is "falling" or "rising", call it out proactively.
 
 ## Gardening & Frost Guidance
 
-When conditions are relevant, include gardening advice:
+Include the guidance below when the user asks about gardening, plants, or yard work, or when a briefing surfaces frost risk, spray-relevant conditions, or significant recent or forecast rain:
 
 - **Frost risk**: Flag when overnight lows are forecast at or below 2°C (36°F). Advise covering or bringing in sensitive plants.
 - **Watering guidance**: If measurable precipitation fell in the last 24 hours (`precip_accum_local_day` or `precip_accum_local_yesterday_final`) or rain is forecast at 50%+ probability in the next 24 hours, suggest skipping manual watering.
@@ -183,7 +183,7 @@ These thresholds are estimates; vertical temperature structure and local elevati
 - **Wet bulb above 1.5°C (35°F)**: Rain.
 - **Air temperature below 0°C with wet bulb near 0°C**: Freezing rain risk — warn about icy surfaces even if precipitation is light.
 
-Mention inferred precipitation type only when temperatures are near or below freezing and precipitation is occurring.
+Mention inferred precipitation type only when precipitation is occurring and the air temperature is at or below 3°C (37°F).
 
 ## Drying Conditions
 


### PR DESCRIPTION
Two workstreams, one file.

## 1. Constraints refactor (original scope)

Audit of the `weather-report` skill against the `separating-context-from-constraints` skill surfaced binding rules buried inside fact-heavy narrative prose. This addresses all six findings:

| Finding | Fix |
|---|---|
| F1 (R4) | Truncation-check rule split out of the forecast bullet onto its own bolded line |
| F2 (R1) | Stale-data bullet now leads with the ">10 min → say so" rule; mechanics follow |
| F3 (R1) | New authoritative **Output** section owns the plain-language + configured-units contract; workflow step 5 references it |
| F4 (R3) | Plain-language rule anchored to a concrete `wind_avg` → described-value example |
| F5 (R2) | Capabilities-consult now front-loads its trigger condition |
| F6 (R1) | Alerts & Anomalies is the sole owner of the proactive-flag list; Pressure and Lightning sections cross-reference instead of restating |

Within this workstream, semantics were preserved — only structure and rule placement changed.

## 2. Skill-review fix series (folded in via merge f5024f1)

A comprehensive review of the skill against the live mcp-server-tempest 0.10.0 surface produced deliberate **semantic** corrections, merged from `main`:

- **Forecast depth**: explicit `hours`/`days` are honored in both modes; the 6/2 default applies only when omitted; `detailed=true` is for field density (replaces the incorrect "summary mode caps output… pass `detailed=true` to lift the cap" claim)
- **`_meta` provenance**: namespaced `_meta["net.bconnelly.tempest/fetch"]` paths
- **Pressure forecasting**: rekeyed to the categorical `pressure_trend` + sea-level pressure (no history API exists, so mb/hr rates were uncomputable); contiguous bands incl. new 1000–1020 mb entry
- **Threshold gaps closed**: spray delta-T 8–10 °C marginal band; air density normal range 1.15–1.30 kg/m³ (was 1.15–1.25 with a gap to 1.30); lightning tiers contiguous at 15 km
- **Observable triggers**: gardening section trigger; precip-type mention gated at ≤3 °C (37 °F) with precip occurring
- **Alert scoping**: proactive alerts scan only already-retrieved data
- **Dedupe/style**: WebSearch caveat single-sourced in the body; Q&A guidance moved into Output; persona framing dropped; one-sentence-per-line reflow

These threshold/condition changes are intended behavior changes, verified against the server's capability surface during review.

🤖 Generated with Claude Code