### PR TITLE
chore(tempest): bump mcp-server-tempest to 0.10.0

### DIFF
--- a/plugins/tempest/.claude-plugin/plugin.json
+++ b/plugins/tempest/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tempest",
   "description": "MCP server for accessing WeatherFlow Tempest personal weather station data",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "Brian Connelly"
   },
@@ -12,7 +12,7 @@
   "mcpServers": {
     "mcp-server-tempest": {
       "command": "uvx",
-      "args": ["mcp-server-tempest==0.9.0"],
+      "args": ["mcp-server-tempest==0.10.0"],
       "env": {
         "WEATHERFLOW_API_TOKEN": "${WEATHERFLOW_API_TOKEN}",
         "WEATHERFLOW_DISK_CACHE_TTL": "${WEATHERFLOW_DISK_CACHE_TTL:-86400}",

--- a/plugins/tempest/.codex-plugin/plugin.json
+++ b/plugins/tempest/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tempest",
-  "version": "0.7.0",
+  "version": "0.10.0",
   "description": "MCP server for accessing WeatherFlow Tempest personal weather station data",
   "author": {
     "name": "Brian Connelly",

--- a/plugins/tempest/.mcp.json
+++ b/plugins/tempest/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "mcp-server-tempest": {
       "command": "uvx",
-      "args": ["mcp-server-tempest==0.7.0"],
+      "args": ["mcp-server-tempest==0.10.0"],
       "env": {
         "WEATHERFLOW_API_TOKEN": "${WEATHERFLOW_API_TOKEN}",
         "WEATHERFLOW_DISK_CACHE_TTL": "${WEATHERFLOW_DISK_CACHE_TTL:-86400}",


### PR DESCRIPTION
Bumps the pinned `mcp-server-tempest` dependency and the tempest plugin version to **0.10.0** (latest on PyPI).

Updated in lockstep:
- `plugins/tempest/.mcp.json` — uvx pin `0.7.0` → `0.10.0`
- `plugins/tempest/.claude-plugin/plugin.json` — `version` + uvx pin `0.9.0` → `0.10.0`
- `plugins/tempest/.codex-plugin/plugin.json` — `version` `0.7.0` → `0.10.0`

🤖 Generated with Claude Code