### PR TITLE
feat(mcp-error-audit): scope error audits to a server release

### DIFF
--- a/plugins/mcp-error-audit/README.md
+++ b/plugins/mcp-error-audit/README.md
@@ -9,6 +9,18 @@ Run `/mcp-error-audit` with no argument for **discovery mode** — every MCP ser
 Run `/mcp-error-audit <server>` to **audit** one server.
 The command aggregates every error returned by that server's tools across all your sessions, classifies each error code, and returns a prioritized fix list.
 
+Scope an audit to a release:
+
+- `--server-version 0.10.0` — only calls whose result reported that release. **Observed.**
+- `--fingerprint <fp>` — only calls whose result reported that contract fingerprint.
+  **Observed**, and available for servers that do not (yet) stamp a version.
+- `--since` / `--until` (`YYYY-MM-DD`) — only calls *started* in that window.
+  **Approximate**: a date is a proxy for a release, and is wrong if you upgraded late.
+- `--group-by version|fingerprint`, `--unknown include|exclude|only`
+
+Calls whose release cannot be read from their own result are reported in an `unknown`
+bucket with a reason, and per-version rates are computed over attributed calls only.
+
 ## How it works
 
 The command runs the bundled `scripts/mcp_error_audit.py` (Python 3, standard library only) against your session transcripts under `~/.claude/projects/`.

--- a/plugins/mcp-error-audit/README.md
+++ b/plugins/mcp-error-audit/README.md
@@ -16,6 +16,7 @@ Scope an audit to a release:
   **Observed**, and available for servers that do not (yet) stamp a version.
 - `--since` / `--until` (`YYYY-MM-DD`) — only calls *started* in that window.
   **Approximate**: a date is a proxy for a release, and is wrong if you upgraded late.
+  Dates must be real calendar dates, and `--since` must not fall after `--until`.
 - `--group-by version|fingerprint`, `--unknown include|exclude|only`
 
 ## Denominators
@@ -25,32 +26,27 @@ Never a statistic whose denominator is a guess.
 - The **header** rate's denominator is whichever calls are currently in scope, and its label names that set.
   Unscoped, that is every matched call, attributed or not.
   Scoped (`--server-version`, `--fingerprint`, `--since`/`--until`, `--unknown`), it is only the calls that scope selected — never "all matched calls".
-- The **matrix** prints one column per release (or fingerprint) *observed in the calls* — so a
-  release you are running that has produced no errors yet still appears, with a zero row over a
-  real call count. Each column carries its own `calls` denominator and an `err%` over it; no
-  release's rate borrows another's calls.
-- Calls whose release cannot be read from their own result land in an `unknown` column with a
-  reason (`no_result`, `unparseable_result`, `not_emitted`), and the report
-  is flagged **PARTIAL**. They never inflate a release's denominator.
+- The **matrix** prints one column per release (or fingerprint) *observed in the calls* — so a release you are running that has produced no errors yet still appears, with a zero row over a real call count.
+  Each column carries its own `calls` denominator and an `err%` over it; no release's rate borrows another's calls.
+  Columns sort in natural (numeric-aware) order for readability — that is not a release chronology, and it does not order prereleases correctly.
+- Calls whose release cannot be read from their own result land in an `unknown` column with a reason (`no_result`, `unparseable_result`, `not_emitted`), and the report is flagged **PARTIAL**.
+  They never inflate a release's denominator.
 - An undated call excluded by `--since`/`--until` is a different case: it may carry a perfectly good version, so it is not filed as unattributed.
   It is excluded from the report entirely, like any other scope exclusion, and counted separately so it never vanishes silently.
 
-A zero in the matrix means **not observed in that release over that column's calls** — not
-"fixed". This tool reads transcripts; it cannot see a code change.
+A zero in the matrix means **not observed in that release over that column's calls** — not "fixed".
+This tool reads transcripts; it cannot see a code change.
 
 ## Known risk: the slash command interpolates your arguments into a shell string
 
 `commands/mcp-error-audit.md` passes `$ARGUMENTS` into a shell command as `--args '$ARGUMENTS'`.
-Arguments containing a single quote can close it and run arbitrary shell commands — e.g.
-`/mcp-error-audit x' ; echo pwned #` executes `echo pwned`.
+Arguments containing a single quote can close it and run arbitrary shell commands — e.g. `/mcp-error-audit x' ; echo pwned #` executes `echo pwned`.
 
-The script's quote check does **not** prevent this (bash tokenizes the string before Python
-starts, so no quote ever reaches Python), and neither does the command's `allowed-tools` entry
-(it is a prefix match, which the injected string still satisfies).
+The script's quote check does **not** prevent this (bash tokenizes the string before Python starts, so no quote ever reaches Python), and neither does the command's `allowed-tools` entry (it is a prefix match, which the injected string still satisfies).
 
-This is a knowingly accepted risk, not an oversight: it predates release scoping, and the only
-caller is your own slash command, typed by you, in your own shell. Closing it properly means not
-interpolating `$ARGUMENTS` into a shell string at all. Do not paste arguments you did not write.
+This is a knowingly accepted risk, not an oversight: it predates release scoping, and the only caller is your own slash command, typed by you, in your own shell.
+Closing it properly means not interpolating `$ARGUMENTS` into a shell string at all.
+Do not paste arguments you did not write.
 
 ## How it works
 

--- a/plugins/mcp-error-audit/README.md
+++ b/plugins/mcp-error-audit/README.md
@@ -18,8 +18,22 @@ Scope an audit to a release:
   **Approximate**: a date is a proxy for a release, and is wrong if you upgraded late.
 - `--group-by version|fingerprint`, `--unknown include|exclude|only`
 
-Calls whose release cannot be read from their own result are reported in an `unknown`
-bucket with a reason, and per-version rates are computed over attributed calls only.
+## Denominators
+
+Never a statistic whose denominator is a guess.
+
+- The **header** rate is `errors ÷ all matched calls`, attributed or not, and says so.
+  It belongs to no single release.
+- The **matrix** prints one column per release (or fingerprint) *observed in the calls* — so a
+  release you are running that has produced no errors yet still appears, with a zero row over a
+  real call count. Each column carries its own `calls` denominator and an `err%` over it; no
+  release's rate borrows another's calls.
+- Calls whose release cannot be read from their own result land in an `unknown` column with a
+  reason (`no_result`, `unparseable_result`, `not_emitted`, `missing_timestamp`), and the report
+  is flagged **PARTIAL**. They never inflate a release's denominator.
+
+A zero in the matrix means **not observed in that release over that column's calls** — not
+"fixed". This tool reads transcripts; it cannot see a code change.
 
 ## How it works
 

--- a/plugins/mcp-error-audit/README.md
+++ b/plugins/mcp-error-audit/README.md
@@ -35,6 +35,20 @@ Never a statistic whose denominator is a guess.
 A zero in the matrix means **not observed in that release over that column's calls** — not
 "fixed". This tool reads transcripts; it cannot see a code change.
 
+## Known risk: the slash command interpolates your arguments into a shell string
+
+`commands/mcp-error-audit.md` passes `$ARGUMENTS` into a shell command as `--args '$ARGUMENTS'`.
+Arguments containing a single quote can close it and run arbitrary shell commands — e.g.
+`/mcp-error-audit x' ; echo pwned #` executes `echo pwned`.
+
+The script's quote check does **not** prevent this (bash tokenizes the string before Python
+starts, so no quote ever reaches Python), and neither does the command's `allowed-tools` entry
+(it is a prefix match, which the injected string still satisfies).
+
+This is a knowingly accepted risk, not an oversight: it predates release scoping, and the only
+caller is your own slash command, typed by you, in your own shell. Closing it properly means not
+interpolating `$ARGUMENTS` into a shell string at all. Do not paste arguments you did not write.
+
 ## How it works
 
 The command runs the bundled `scripts/mcp_error_audit.py` (Python 3, standard library only) against your session transcripts under `~/.claude/projects/`.

--- a/plugins/mcp-error-audit/README.md
+++ b/plugins/mcp-error-audit/README.md
@@ -22,15 +22,18 @@ Scope an audit to a release:
 
 Never a statistic whose denominator is a guess.
 
-- The **header** rate is `errors ÷ all matched calls`, attributed or not, and says so.
-  It belongs to no single release.
+- The **header** rate's denominator is whichever calls are currently in scope, and its label names that set.
+  Unscoped, that is every matched call, attributed or not.
+  Scoped (`--server-version`, `--fingerprint`, `--since`/`--until`, `--unknown`), it is only the calls that scope selected — never "all matched calls".
 - The **matrix** prints one column per release (or fingerprint) *observed in the calls* — so a
   release you are running that has produced no errors yet still appears, with a zero row over a
   real call count. Each column carries its own `calls` denominator and an `err%` over it; no
   release's rate borrows another's calls.
 - Calls whose release cannot be read from their own result land in an `unknown` column with a
-  reason (`no_result`, `unparseable_result`, `not_emitted`, `missing_timestamp`), and the report
+  reason (`no_result`, `unparseable_result`, `not_emitted`), and the report
   is flagged **PARTIAL**. They never inflate a release's denominator.
+- An undated call excluded by `--since`/`--until` is a different case: it may carry a perfectly good version, so it is not filed as unattributed.
+  It is excluded from the report entirely, like any other scope exclusion, and counted separately so it never vanishes silently.
 
 A zero in the matrix means **not observed in that release over that column's calls** — not
 "fixed". This tool reads transcripts; it cannot see a code change.

--- a/plugins/mcp-error-audit/commands/mcp-error-audit.md
+++ b/plugins/mcp-error-audit/commands/mcp-error-audit.md
@@ -1,12 +1,12 @@
 ---
 description: Audit MCP tool errors across all your Claude Code sessions and prioritize fixes
-argument-hint: "[server name or substring — letters/digits/._- only; empty lists all servers]"
+argument-hint: "[server] [--server-version X] [--fingerprint FP] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--group-by version|fingerprint] [--unknown include|exclude|only]"
 allowed-tools: Bash(python3 ${CLAUDE_PLUGIN_ROOT}/scripts/mcp_error_audit.py:*)
 ---
 
 ## Error audit data
 
-!`python3 ${CLAUDE_PLUGIN_ROOT}/scripts/mcp_error_audit.py --server '$ARGUMENTS'`
+!`python3 ${CLAUDE_PLUGIN_ROOT}/scripts/mcp_error_audit.py --args '$ARGUMENTS'`
 
 ## Your task
 
@@ -26,6 +26,20 @@ Subagent transcripts are folded into their parent session, and both bare and plu
 If the report includes a `WARNING:` that the matched servers look distinct, lead with that caveat and suggest narrowing the server argument, since the blended stats may mislead.
 `repair` hints come from each code's most recent occurrence that included one.
 Each sample line shows the occurrence date, the tool input, and the error text; `recov` counts errors followed later in the same transcript by a success of the same tool.
+
+If the report is scoped (`--server-version`, `--fingerprint`, `--since/--until`), say so in
+your answer, and carry its caveats:
+
+- A code absent from a version means **not observed in that version over the attributed
+  calls shown** — NOT "fixed". This tool reads transcripts; it cannot see a code change.
+  Say "not observed in 0.10.0 over N attributed calls", and only call something fixed if
+  you have separate evidence (a changelog entry, the code itself).
+- If the report says rates are PARTIAL, lead with that: they are computed over calls whose
+  release could be attributed, not over all calls.
+- If the report says the scope is date-based and APPROXIMATE, note that a date is a proxy
+  for a release and is wrong if the user upgraded late or ran a dev tree.
+- `cross` counts a later success of the same tool at a *different* version. It is NOT a
+  recovery — the environment changed — so treat that code's recovery as indeterminate.
 
 Analyze the report and give me a **prioritized, actionable list of what to fix** — do not just restate the table.
 Apply this lens; if an `agent-friendly-mcp` skill is available, apply its failure-recovery and tool-design guidance in addition, and where the two conflict, the numbered lens below wins.

--- a/plugins/mcp-error-audit/commands/mcp-error-audit.md
+++ b/plugins/mcp-error-audit/commands/mcp-error-audit.md
@@ -27,25 +27,24 @@ If the report includes a `WARNING:` that the matched servers look distinct, lead
 `repair` hints come from each code's most recent occurrence that included one.
 Each sample line shows the occurrence date, the tool input, and the error text; `recov` counts errors followed later in the same transcript by a success of the same tool *at the same attributed scope*.
 
-If the report is scoped (`--server-version`, `--fingerprint`, `--since/--until`), say so in
-your answer, and carry its caveats:
+If the report is scoped (`--server-version`, `--fingerprint`, `--since`/`--until`, or `--unknown exclude|only`), say so in your answer, and carry its caveats.
+`--unknown exclude|only` narrows the population like any other filter — the report's header labels it as scoped, so do not present an attributed-only or unknown-only audit as if it covered everything.
 
 - A code absent from a version means **not observed in that version over that column's calls** — NOT "fixed".
   This tool reads transcripts; it cannot see a code change.
   Say "not observed in 0.10.0 over N calls", taking N from the matrix's `calls` row for **that column** — that is the column's own denominator.
   Prefer that column's own `calls` row over the header's total call count: the header's denominator is whatever the ACTIVE filters selected — every matched call when the report is unscoped, but only that filter's calls when `--server-version`/`--fingerprint`/`--since`/`--until` narrow it — so it is easy to grab the wrong number, and the matrix's own per-column `calls` row is unambiguous regardless of scope.
   Only call something fixed if you have separate evidence (a changelog entry, the code itself).
-- If the report says rates are PARTIAL, lead with that: they are computed over calls whose
-  release could be attributed, not over all calls.
-- If the report says the scope is date-based and APPROXIMATE, note that a date is a proxy
-  for a release and is wrong if the user upgraded late or ran a dev tree.
-- `cross` counts a later success of the same tool at a *different or unknown* version. It is
-  NOT a recovery — the environment changed, or we cannot tell that it didn't — so treat that
-  code's recovery as indeterminate.
-- Therefore, when a server does not stamp a version, **every** call is version-unknown and
-  `recov` is 0 across the board while `cross` carries the counts. Do NOT read that as "this
-  code never recovers" — it means recovery is unmeasurable at this scope. Re-run with
-  `--group-by fingerprint` to get a measurable one, and rank on that instead.
+- If the report says coverage is PARTIAL, lead with that: some selected calls could not be attributed to the active dimension.
+  Each known-scope matrix column divides by its own attributed-call denominator, the unattributable calls are isolated in the `unknown` column, and the header's overall rate spans every call the active filters selected — attributed or not.
+  Do not describe that header rate as attributed-only; the report does not compute one.
+- If the report says the scope is date-based and APPROXIMATE, note that a date is a proxy for a release and is wrong if the user upgraded late or ran a dev tree.
+- `cross` counts a later success of the same tool at a *different or unknown scope under the active `--group-by` dimension*.
+  Under `--group-by fingerprint` that means a different fingerprint, not a different release — do not claim the server version changed.
+  It is NOT a recovery — the environment changed, or we cannot tell that it didn't — so treat that code's recovery as indeterminate.
+- Therefore, when a server does not stamp a version, **every** call is version-unknown and `recov` is 0 across the board while `cross` carries the counts.
+  Do NOT read that as "this code never recovers" — it means recovery is unmeasurable at this scope.
+  Re-run with `--group-by fingerprint` to get a measurable one, and rank on that instead.
 
 Analyze the report and give me a **prioritized, actionable list of what to fix** — do not just restate the table.
 Apply this lens; if an `agent-friendly-mcp` skill is available, apply its failure-recovery and tool-design guidance in addition, and where the two conflict, the numbered lens below wins.
@@ -64,6 +63,8 @@ Apply this lens; if an `agent-friendly-mcp` skill is available, apply its failur
 
 5. **Discount stale signatures — but never promote "stale" to "fixed".** Judge staleness of a code's `last_seen` relative to the server's recent activity (the `last call` date in the report header), not by a fixed window: a code absent for a month means little if the server was idle too.
    A code old relative to recent activity, or whose samples reference tools/params no longer in the server's surface, is a candidate to **deprioritize**: say it looks stale, say what makes it look stale, and stop there.
-   A date is only a *proxy* for a release. Where the matrix carries real scope evidence, that evidence outranks the date heuristic — prefer "not observed in 0.10.0 over N calls" to any argument from age. Either way, calling a code **fixed** requires evidence this tool cannot produce (a changelog entry, the code itself); transcripts show what was observed, never what was changed.
+   A date is only a *proxy* for a release.
+   Where the matrix carries real scope evidence, that evidence outranks the date heuristic — prefer "not observed in 0.10.0 over N calls" to any argument from age.
+   Either way, calling a code **fixed** requires evidence this tool cannot produce (a changelog entry, the code itself); transcripts show what was observed, never what was changed.
 
 End with an ordered TODO list of at most 7 items.

--- a/plugins/mcp-error-audit/commands/mcp-error-audit.md
+++ b/plugins/mcp-error-audit/commands/mcp-error-audit.md
@@ -25,21 +25,29 @@ About the data: the report aggregates every error returned by the matched MCP se
 Subagent transcripts are folded into their parent session, and both bare and plugin-hosted tool-name forms are merged — the `matched:` line shows which.
 If the report includes a `WARNING:` that the matched servers look distinct, lead with that caveat and suggest narrowing the server argument, since the blended stats may mislead.
 `repair` hints come from each code's most recent occurrence that included one.
-Each sample line shows the occurrence date, the tool input, and the error text; `recov` counts errors followed later in the same transcript by a success of the same tool.
+Each sample line shows the occurrence date, the tool input, and the error text; `recov` counts errors followed later in the same transcript by a success of the same tool *at the same attributed scope*.
 
 If the report is scoped (`--server-version`, `--fingerprint`, `--since/--until`), say so in
 your answer, and carry its caveats:
 
-- A code absent from a version means **not observed in that version over the attributed
-  calls shown** — NOT "fixed". This tool reads transcripts; it cannot see a code change.
-  Say "not observed in 0.10.0 over N attributed calls", and only call something fixed if
-  you have separate evidence (a changelog entry, the code itself).
+- A code absent from a version means **not observed in that version over that column's
+  calls** — NOT "fixed". This tool reads transcripts; it cannot see a code change.
+  Say "not observed in 0.10.0 over N calls", taking N from the matrix's `calls` row for
+  **that column** — that is the column's own denominator. Never pair a single version with
+  the header's total call count: it spans every version, and a denominator that borrows
+  another release's calls is a lie. Only call something fixed if you have separate
+  evidence (a changelog entry, the code itself).
 - If the report says rates are PARTIAL, lead with that: they are computed over calls whose
   release could be attributed, not over all calls.
 - If the report says the scope is date-based and APPROXIMATE, note that a date is a proxy
   for a release and is wrong if the user upgraded late or ran a dev tree.
-- `cross` counts a later success of the same tool at a *different* version. It is NOT a
-  recovery — the environment changed — so treat that code's recovery as indeterminate.
+- `cross` counts a later success of the same tool at a *different or unknown* version. It is
+  NOT a recovery — the environment changed, or we cannot tell that it didn't — so treat that
+  code's recovery as indeterminate.
+- Therefore, when a server does not stamp a version, **every** call is version-unknown and
+  `recov` is 0 across the board while `cross` carries the counts. Do NOT read that as "this
+  code never recovers" — it means recovery is unmeasurable at this scope. Re-run with
+  `--group-by fingerprint` to get a measurable one, and rank on that instead.
 
 Analyze the report and give me a **prioritized, actionable list of what to fix** — do not just restate the table.
 Apply this lens; if an `agent-friendly-mcp` skill is available, apply its failure-recovery and tool-design guidance in addition, and where the two conflict, the numbered lens below wins.
@@ -56,7 +64,8 @@ Apply this lens; if an `agent-friendly-mcp` skill is available, apply its failur
 
 4. **Check whether `repair` hints name real recovery paths.** If a retryable error's hint omits a better escape hatch (e.g. an `_async` variant for a timeout), flag it — repair hints should point at real callable surfaces.
 
-5. **Discount stale signatures.** Judge staleness of a code's `last_seen` relative to the server's recent activity (the `last call` date in the report header), not by a fixed window: a code absent for a month means little if the server was idle too.
-   A code old relative to recent activity, or whose samples reference tools/params no longer in the server's surface, is likely already fixed — say so rather than recommending a fix for it.
+5. **Discount stale signatures — but never promote "stale" to "fixed".** Judge staleness of a code's `last_seen` relative to the server's recent activity (the `last call` date in the report header), not by a fixed window: a code absent for a month means little if the server was idle too.
+   A code old relative to recent activity, or whose samples reference tools/params no longer in the server's surface, is a candidate to **deprioritize**: say it looks stale, say what makes it look stale, and stop there.
+   A date is only a *proxy* for a release. Where the matrix carries real scope evidence, that evidence outranks the date heuristic — prefer "not observed in 0.10.0 over N calls" to any argument from age. Either way, calling a code **fixed** requires evidence this tool cannot produce (a changelog entry, the code itself); transcripts show what was observed, never what was changed.
 
 End with an ordered TODO list of at most 7 items.

--- a/plugins/mcp-error-audit/commands/mcp-error-audit.md
+++ b/plugins/mcp-error-audit/commands/mcp-error-audit.md
@@ -30,13 +30,11 @@ Each sample line shows the occurrence date, the tool input, and the error text; 
 If the report is scoped (`--server-version`, `--fingerprint`, `--since/--until`), say so in
 your answer, and carry its caveats:
 
-- A code absent from a version means **not observed in that version over that column's
-  calls** — NOT "fixed". This tool reads transcripts; it cannot see a code change.
-  Say "not observed in 0.10.0 over N calls", taking N from the matrix's `calls` row for
-  **that column** — that is the column's own denominator. Never pair a single version with
-  the header's total call count: it spans every version, and a denominator that borrows
-  another release's calls is a lie. Only call something fixed if you have separate
-  evidence (a changelog entry, the code itself).
+- A code absent from a version means **not observed in that version over that column's calls** — NOT "fixed".
+  This tool reads transcripts; it cannot see a code change.
+  Say "not observed in 0.10.0 over N calls", taking N from the matrix's `calls` row for **that column** — that is the column's own denominator.
+  Prefer that column's own `calls` row over the header's total call count: the header's denominator is whatever the ACTIVE filters selected — every matched call when the report is unscoped, but only that filter's calls when `--server-version`/`--fingerprint`/`--since`/`--until` narrow it — so it is easy to grab the wrong number, and the matrix's own per-column `calls` row is unambiguous regardless of scope.
+  Only call something fixed if you have separate evidence (a changelog entry, the code itself).
 - If the report says rates are PARTIAL, lead with that: they are computed over calls whose
   release could be attributed, not over all calls.
 - If the report says the scope is date-based and APPROXIMATE, note that a date is a proxy

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -32,6 +32,54 @@ from glob import glob
 
 VALID_SERVER = re.compile(r"^[A-Za-z0-9._-]+$")
 
+# The label used wherever a call's release could not be attributed from its own result.
+UNKNOWN = "unknown"
+
+# Exact paths, in precedence order. NEVER a regex over key names: a server may emit an
+# unrelated version (codex-in-claude emits `codex_version`, the Codex CLI's version),
+# and a name-matching heuristic would report on the wrong software. Both `meta.*` and
+# top-level shapes are required — in real corpora roughly half of all results carry no
+# `meta` at all (job/status envelopes), and those carry their identity at top level.
+VERSION_PATHS = (
+    ("meta", "server_version"),
+    ("server_version",),
+    ("meta", "server", "version"),
+    ("server", "version"),
+)
+FINGERPRINT_PATHS = (
+    ("meta", "fingerprint"),
+    ("fingerprint",),
+)
+
+
+def _dig(obj, path: tuple[str, ...]) -> str | None:
+    """The non-empty string at `path` in `obj`, or None. Never raises on odd shapes."""
+    cur = obj
+    for key in path:
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(key)
+    return cur if isinstance(cur, str) and cur else None
+
+
+def _first_at_paths(obj, paths) -> str | None:
+    for path in paths:
+        found = _dig(obj, path)
+        if found:
+            return found
+    return None
+
+
+def extract_version(obj) -> str | None:
+    """The server's own release, from an allowlisted path in its result envelope."""
+    return _first_at_paths(obj, VERSION_PATHS)
+
+
+def extract_fingerprint(obj) -> str | None:
+    """The server's contract/surface id, from an allowlisted path."""
+    return _first_at_paths(obj, FINGERPRINT_PATHS)
+
+
 # Servers with fewer calls than this sort below the rest: a 1-for-1 error
 # rate is noise, not signal.
 MIN_CALLS_FOR_RATE = 5

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -895,7 +895,6 @@ def to_text(result) -> str:
         # data stay aligned instead of running together. MIN_SCOPE_COL keeps narrow
         # counts from crowding a short label like "1.0.0".
         col_width = max(MIN_SCOPE_COL, max(len(sc) for sc in scopes))
-        errs = errors_by_scope(result)
         out.append(f"\n## Errors by code × {dim}")
         header = f"{'code':<34}" + "".join(f" {sc:>{col_width}}" for sc in scopes)
         out.append(header)

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -84,6 +84,10 @@ def extract_fingerprint(obj) -> str | None:
 # rate is noise, not signal.
 MIN_CALLS_FOR_RATE = 5
 
+# Floor for the code×scope matrix's per-scope column width, so short version
+# labels ("1.0.0") don't crowd their counts.
+MIN_SCOPE_COL = 6
+
 
 def server_sort_key(kv):
     """Discovery ranking: error rate desc, low-volume servers last."""
@@ -756,11 +760,18 @@ def to_text(result) -> str:
 
     scopes = sorted({sc for s in result["codes"].values() for sc in s.by_scope})
     if scopes:
+        # Column width follows the widest scope label (version strings are short;
+        # fingerprints like "codex-in-claude/0.1/schema-38" are not) so headers and
+        # data stay aligned instead of running together. MIN_SCOPE_COL keeps narrow
+        # counts from crowding a short label like "1.0.0".
+        col_width = max(MIN_SCOPE_COL, max(len(sc) for sc in scopes))
         out.append(f"\n## Errors by code × {dim}")
-        header = f"{'code':<34}" + "".join(f"{sc:>14}" for sc in scopes)
+        header = f"{'code':<34}" + "".join(f" {sc:>{col_width}}" for sc in scopes)
         out.append(header)
         for code, s in sorted_codes(result):
-            row = f"{code:<34}" + "".join(f"{s.by_scope.get(sc, 0):>14}" for sc in scopes)
+            row = f"{code:<34}" + "".join(
+                f" {s.by_scope.get(sc, 0):>{col_width}}" for sc in scopes
+            )
             out.append(row)
         out.append(
             "\nA zero above means NOT OBSERVED in that "

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -15,7 +15,11 @@ With no --server, runs discovery mode: lists every MCP server seen in the
 transcripts with call/error/session counts.
 
 Usage:
-    mcp_error_audit.py [--server SUBSTRING] [--json] [--root DIR] [--samples N]
+    mcp_error_audit.py [SERVER] [--server-version V] [--fingerprint FP]
+                       [--since YYYY-MM-DD] [--until YYYY-MM-DD]
+                       [--group-by version|fingerprint] [--unknown include|exclude|only]
+                       [--json] [--root DIR] [--samples N]
+    mcp_error_audit.py --args "SERVER [FLAGS...]"   # re-parsed with shlex; no quotes allowed
 
 Standard library only.
 """
@@ -27,10 +31,17 @@ import collections
 import json
 import os
 import re
+import shlex
 from dataclasses import dataclass, field
 from glob import glob
 
 VALID_SERVER = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# The server token stays strict. A fingerprint carries '/' (e.g. srv/0.1/schema-38), so
+# it needs its own class — do NOT widen VALID_SERVER to accept it.
+VALID_FINGERPRINT = re.compile(r"^[A-Za-z0-9._/-]+$")
+VALID_VERSION = re.compile(r"^[A-Za-z0-9.+_-]+$")
+VALID_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 # The label used wherever a call's release could not be attributed from its own result.
 UNKNOWN = "unknown"
@@ -817,34 +828,75 @@ def to_text(result) -> str:
     return "\n".join(out)
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--server",
+        "server",
+        nargs="?",
         default="",
-        help="MCP server name or substring (empty/omitted → discovery mode "
-        "listing all servers)",
+        help="MCP server name or substring (omit → discovery mode listing all servers)",
     )
-    parser.add_argument(
-        "--root",
-        default=os.path.expanduser("~/.claude/projects"),
-        help="Directory of session transcripts",
-    )
-    parser.add_argument(
-        "--json", action="store_true", help="Emit JSON instead of a table"
-    )
-    parser.add_argument(
-        "--samples", type=int, default=3, help="Sample error texts per code"
-    )
-    args = parser.parse_args()
+    parser.add_argument("--server", dest="server_opt", default=None,
+                        help=argparse.SUPPRESS)  # back-compat with the old invocation
+    parser.add_argument("--server-version", default=None,
+                        help="Only calls whose result reported this server release (observed)")
+    parser.add_argument("--fingerprint", default=None,
+                        help="Only calls whose result reported this contract fingerprint (observed)")
+    parser.add_argument("--since", default=None, help="Only calls STARTED on/after this date (YYYY-MM-DD; approximate)")
+    parser.add_argument("--until", default=None, help="Only calls STARTED on/before this date (YYYY-MM-DD; approximate)")
+    parser.add_argument("--group-by", choices=("version", "fingerprint"), default="version",
+                        help="Dimension for the matrix and for scope-aware recovery")
+    parser.add_argument("--unknown", choices=("include", "exclude", "only"), default="include",
+                        help="Calls whose release could not be attributed")
+    parser.add_argument("--root", default=os.path.expanduser("~/.claude/projects"),
+                        help="Directory of session transcripts")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of a table")
+    parser.add_argument("--samples", type=int, default=3, help="Sample error texts per code")
+    parser.add_argument("--args", dest="args_string", default=None,
+                        help="Raw argument string from the slash command; re-parsed as flags")
+    return parser
+
+
+def parse_argv(argv) -> argparse.Namespace:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.args_string is not None:
+        # The slash command interpolates $ARGUMENTS inside single quotes. A quote in the
+        # input would break out of them, so refuse it rather than risk a shell escape.
+        if "'" in args.args_string or '"' in args.args_string:
+            parser.error("quotes are not allowed in the command arguments")
+        args = parser.parse_args(shlex.split(args.args_string))
+
+    if args.server_opt is not None:  # legacy --server wins when explicitly given
+        args.server = args.server_opt
 
     server = (args.server or "").strip()
     if server and not VALID_SERVER.match(server):
-        parser.error(
-            f"invalid --server value {server!r}: expected characters in [A-Za-z0-9._-]"
-        )
+        parser.error(f"invalid server {server!r}: expected characters in [A-Za-z0-9._-]")
+    args.server = server
 
-    result = audit(args.root, server, args.samples)
+    if args.server_version and not VALID_VERSION.match(args.server_version):
+        parser.error(f"invalid --server-version {args.server_version!r}")
+    if args.fingerprint and not VALID_FINGERPRINT.match(args.fingerprint):
+        parser.error(f"invalid --fingerprint {args.fingerprint!r}")
+    for flag, value in (("--since", args.since), ("--until", args.until)):
+        if value and not VALID_DATE.match(value):
+            parser.error(f"invalid {flag} {value!r}: expected YYYY-MM-DD")
+    return args
+
+
+def main() -> None:
+    args = parse_argv(None)
+    filters = Filters(
+        server_version=args.server_version,
+        fingerprint=args.fingerprint,
+        since=args.since,
+        until=args.until,
+        group_by=args.group_by,
+        unknown=args.unknown,
+    )
+    result = audit(args.root, args.server, args.samples, filters)
     print(to_json(result) if args.json else to_text(result))
 
 

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -470,6 +470,14 @@ class Coverage:
     # some selected calls could not be attributed, so the buckets sum to every call
     # aggregate() saw.
     calls_by_scope: collections.Counter = field(default_factory=collections.Counter)
+    # Calls a date filter (--since/--until) dropped because they carried no timestamp to
+    # place in the window. This is a SCOPE EXCLUSION, not an attribution failure — an
+    # undated call may carry a perfectly good version, so it must NOT land in `unknown`
+    # or count toward `total_calls`/`attributed_calls`: the same as every other filter
+    # exclusion (version/fingerprint mismatch, --unknown exclude/only), none of which
+    # touch coverage either. Tracked separately purely so the report can say how many
+    # calls a date scope dropped, instead of letting them vanish silently.
+    excluded_missing_timestamp: int = 0
 
     def partial(self) -> bool:
         """True when some calls could not be attributed — every rate is then partial."""
@@ -530,8 +538,11 @@ class Filters:
             # The CALL's start time, never the result's: filtering the two records
             # independently would split a pair and manufacture phantom no_result calls.
             if not rec.ts:
-                coverage.total_calls += 1
-                coverage.unknown["missing_timestamp"] += 1
+                # Excluded by the date window, not a failure to attribute: an undated
+                # call may carry a perfectly good version. Do not touch total_calls or
+                # unknown — every other filter exclusion (version/fingerprint mismatch,
+                # --unknown exclude/only) leaves coverage alone too, and this must match.
+                coverage.excluded_missing_timestamp += 1
                 return False
             day = rec.ts[:10]
             if self.since and day < self.since:
@@ -685,18 +696,37 @@ def errors_by_scope(result) -> collections.Counter:
     return total
 
 
+_NUMERIC_RUN = re.compile(r"(\d+)")
+
+
+def natural_sort_key(s: str) -> list[tuple[int, object]]:
+    """Split `s` into text/number chunks so numeric runs compare BY VALUE.
+
+    A plain string sort puts "0.10.0" before "0.9.0" and "schema-10" before
+    "schema-2" — wrong for both version numbers and fingerprint schema ids, whose
+    whole point is to read as a trajectory toward the newest release. Each chunk is
+    tagged (0, str) or (1, int) so chunks of different types never get compared
+    directly against each other (which would raise); only same-position, same-type
+    chunks are ever compared, and the tag alone breaks ties across types.
+    """
+    chunks = [c for c in _NUMERIC_RUN.split(s) if c != ""]
+    return [(1, int(c)) if c.isdigit() else (0, c) for c in chunks]
+
+
 def matrix_scopes(result) -> list[str]:
     """The matrix's columns, derived from CALL scopes — not error scopes.
 
     A release whose calls all succeeded has no error rows, but it still gets a column
     (all zeros, over a real call denominator). The error scopes are unioned in purely
     defensively; they are a subset of the call scopes by construction. UNKNOWN sorts
-    last so observed releases read left-to-right.
+    last; the rest sort in natural (numeric-aware) order so observed releases read
+    left-to-right toward the newest one — "0.9.0" before "0.10.0", "schema-3" before
+    "schema-10" — instead of a lexicographic sort that would put them backwards.
     """
     scopes = set(result["coverage"].calls_by_scope) | {
         sc for stat in result["codes"].values() for sc in stat.by_scope
     }
-    return sorted(scopes, key=lambda sc: (sc == UNKNOWN, sc))
+    return sorted(scopes, key=lambda sc: (sc == UNKNOWN, natural_sort_key(sc)))
 
 
 def scope_rate(result, scope: str) -> str:
@@ -784,6 +814,7 @@ def to_json(result) -> str:
                 "total_calls": result["coverage"].total_calls,
                 "attributed_calls": result["coverage"].attributed_calls,
                 "unknown": dict(result["coverage"].unknown),
+                "excluded_missing_timestamp": result["coverage"].excluded_missing_timestamp,
                 "partial": result["coverage"].partial(),
                 "group_by": result["filters"].group_by,
                 "date_scoped": result["filters"].date_scoped(),
@@ -824,10 +855,18 @@ def to_text(result) -> str:
 
     calls = sum(result["total_calls"].values())
     errors = sum(result["total_errors"].values())
-    # This rate spans EVERY matched call, attributed or not. That is a legitimate
-    # figure — but it belongs to no single release, so it is labeled as what it is.
-    # The per-release rates live in the matrix, each over its own denominator.
-    rate = f"{100 * errors / calls:.1f}% of all matched calls, attributed or not" if calls else "n/a"
+    # `calls` is every SELECTED call — every matched call when unscoped, but only
+    # whatever the active --server-version/--fingerprint/--since/--until/--unknown
+    # filters left in when scoped. The label must name whichever set that actually
+    # is: it must never claim "all matched calls" on a scoped run, where the true
+    # all-matched count lives in raw_matched_calls instead. The per-release rates
+    # live in the matrix, each over its own denominator.
+    active_filters = result["filters"].describe_active()
+    denom_desc = (
+        f"calls scoped to {active_filters}" if active_filters
+        else "all matched calls, attributed or not"
+    )
+    rate = f"{100 * errors / calls:.1f}% of {denom_desc}" if calls else "n/a"
     n_sess = len(result["audit_sessions"])
     out.append(f"# MCP error audit — servers matching '{result['server']}'")
     if not calls:
@@ -879,14 +918,25 @@ def to_text(result) -> str:
             f"Each {dim} column in the matrix below has its own denominator (its `calls` "
             f"row), so no release's rate borrows another's calls; the unattributable ones "
             "are isolated in the `unknown` column instead of inflating any release. The "
-            "overall rate in the header spans all matched calls, attributed or not."
+            f"overall rate in the header spans {denom_desc}."
         )
     if result["filters"].date_scoped():
-        out.append(
+        note = (
             "NOTE: date-scoped, APPROXIMATE — a date is a proxy for a release. It is wrong "
             "if you upgraded late or ran a dev tree between releases. Prefer "
             "--server-version or --fingerprint, which are observed in the envelope."
         )
+        if cov.excluded_missing_timestamp:
+            # These calls are NOT in total_calls/attributed_calls/unknown above — they
+            # were excluded from the report entirely, the same as any other scope
+            # exclusion, because an undated call may well have a perfectly good version.
+            # Named here so they do not vanish silently.
+            note += (
+                f" {cov.excluded_missing_timestamp} calls with no timestamp could not be "
+                "placed in the date window and were excluded from every count above "
+                "(not counted as unattributed — they may well carry a version)."
+            )
+        out.append(note)
 
     scopes = matrix_scopes(result)
     if scopes:

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -911,11 +911,20 @@ def parse_argv(argv) -> argparse.Namespace:
     args = parser.parse_args(argv)
 
     if args.args_string is not None:
-        # The slash command interpolates $ARGUMENTS inside single quotes. A quote in the
-        # input would break out of them, so refuse it rather than risk a shell escape.
+        # Defense-in-depth at the PYTHON layer only: rejecting quotes here keeps a
+        # stray quote from producing a confusing shlex parse. It does NOT and cannot
+        # prevent shell injection: bash tokenizes the interpolated $ARGUMENTS before
+        # this script ever runs, so anything that breaks out of the shell quoting in
+        # commands/mcp-error-audit.md has already happened by the time we see argv.
+        # The `allowed-tools` allowlist in that command file is what guards the shell
+        # layer.
         if "'" in args.args_string or '"' in args.args_string:
             parser.error("quotes are not allowed in the command arguments")
-        args = parser.parse_args(shlex.split(args.args_string))
+        try:
+            split = shlex.split(args.args_string)
+        except ValueError as exc:
+            parser.error(f"could not parse command arguments: {exc}")
+        args = parser.parse_args(split)
 
     if args.server_opt is not None:  # legacy --server wins when explicitly given
         args.server = args.server_opt
@@ -932,6 +941,18 @@ def parse_argv(argv) -> argparse.Namespace:
     for flag, value in (("--since", args.since), ("--until", args.until)):
         if value and not VALID_DATE.match(value):
             parser.error(f"invalid {flag} {value!r}: expected YYYY-MM-DD")
+    if args.unknown == "only" and (args.server_version or args.fingerprint):
+        # An unattributed record has no version/fingerprint to compare, so it can
+        # never equal a specific observed value. --unknown only combined with
+        # --server-version or --fingerprint is vacuous by construction: the result
+        # is always empty, regardless of corpus. Reject rather than silently
+        # report zero results, which reads as "your corpus has none".
+        parser.error(
+            "--unknown only combined with --server-version/--fingerprint always "
+            "yields zero results: an unattributed record can never match a "
+            "specific observed value. Drop --unknown only, or drop the version/"
+            "fingerprint filter."
+        )
     return args
 
 

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -449,14 +449,40 @@ class Coverage:
 
 @dataclass
 class Filters:
+    """Scope selection. `server_version` and `fingerprint` are OBSERVED facts read from
+    the envelope. `since`/`until` are an APPROXIMATION — a date is a proxy for a release
+    and breaks when the user upgrades late or runs a dev tree between releases."""
+
     server_version: str | None = None
     fingerprint: str | None = None
     since: str | None = None
     until: str | None = None
-    group_by: str = "version"
-    unknown: str = "include"
+    group_by: str = "version"  # version | fingerprint
+    unknown: str = "include"  # include | exclude | only
+
+    def date_scoped(self) -> bool:
+        return bool(self.since or self.until)
 
     def selects(self, rec: CallRecord, coverage: Coverage) -> bool:
+        if self.unknown == "exclude" and rec.unknown_reason:
+            return False
+        if self.unknown == "only" and not rec.unknown_reason:
+            return False
+        if self.server_version and rec.version != self.server_version:
+            return False
+        if self.fingerprint and rec.fingerprint != self.fingerprint:
+            return False
+        if self.date_scoped():
+            # The CALL's start time, never the result's: filtering the two records
+            # independently would split a pair and manufacture phantom no_result calls.
+            if not rec.ts:
+                coverage.unknown["missing_timestamp"] += 1
+                return False
+            day = rec.ts[:10]
+            if self.since and day < self.since:
+                return False
+            if self.until and day > self.until:
+                return False
         return True
 
 

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -381,13 +381,22 @@ def records_for_file(path: str, root: str) -> list[CallRecord]:
 class CodeStat:
     count: int = 0
     recovered: int = 0
-    sessions: set[str] = field(default_factory=set)
+    # A later success of the same tool at a DIFFERENT (or unknown) version. Not a
+    # recovery: the environment changed, so this version's recovery is indeterminate.
+    cross_version_success: int = 0
+    sessions: set[tuple[str, str]] = field(default_factory=set)  # (scope, session)
+    by_scope: collections.Counter = field(default_factory=collections.Counter)
     tools: collections.Counter = field(default_factory=collections.Counter)
     retryable: bool | None = None
     repair: str | None = None
     first_seen: str | None = None
     last_seen: str | None = None
     samples: list = field(default_factory=list)
+
+    def session_count(self) -> int:
+        """Distinct sessions, NOT (scope, session) pairs — one session may span two
+        versions, and counting pairs would double-count it."""
+        return len({session for _scope, session in self.sessions})
 
     def add_sample(self, ts: str | None, input_snippet: str, text: str, limit: int):
         """Keep the `limit` most recent samples (recent evidence beats stale)."""
@@ -463,34 +472,42 @@ def aggregate(
 ) -> None:
     """Fold one transcript's selected call records into the running totals.
 
-    Recovery is scoped per file: a later SUCCESS for the same tool retires the codes
-    still `pending` for that tool. Records must arrive in the RESULT order
-    `records_for_file` returns (unpaired calls last) so recovery sees results in the
-    order they actually landed, and unanswered calls never masquerade as a success.
+    An error is resolved by the FIRST later success of the same tool. Same scope ->
+    recovered. Different or unknown scope -> indeterminate (cross_version_success).
+    Records must arrive in the RESULT order `records_for_file` returns (unpaired calls
+    last) so recovery sees results in the order they actually landed, and unanswered
+    calls never masquerade as a success.
     """
-    pending: dict[str, list[str]] = collections.defaultdict(list)
+    pending: dict[tuple[str, str], list[str]] = collections.defaultdict(list)
+
     for rec in records:
+        scope = rec.scope(filters.group_by)
         total_calls[rec.tool] += 1
         audit_sessions.add(rec.session)
         coverage.total_calls += 1
-        if rec.unknown_reason is None:
-            coverage.attributed_calls += 1
-        else:
+        if rec.unknown_reason:
             coverage.unknown[rec.unknown_reason] += 1
+        else:
+            coverage.attributed_calls += 1
 
         if rec.unknown_reason == "no_result":
             continue  # never answered: nothing to classify or recover
 
         if not rec.is_error:
-            for code in pending.pop(rec.tool, []):
-                codes[code].recovered += 1
+            for (tool, pend_scope) in [k for k in pending if k[0] == rec.tool]:
+                for code in pending.pop((tool, pend_scope)):
+                    if pend_scope == scope:
+                        codes[code].recovered += 1
+                    else:
+                        codes[code].cross_version_success += 1
             continue
 
         total_errors[rec.tool] += 1
         assert rec.code is not None  # classify() always sets code when is_error is True
         stat = codes[rec.code]
         stat.count += 1
-        stat.sessions.add(rec.session)
+        stat.sessions.add((scope, rec.session))
+        stat.by_scope[scope] += 1
         stat.tools[rec.tool] += 1
         if stat.see(rec.ts):
             if rec.retryable is not None:
@@ -498,7 +515,7 @@ def aggregate(
             if rec.repair:
                 stat.repair = rec.repair
         stat.add_sample(rec.ts, rec.input, rec.text, samples)
-        pending[rec.tool].append(rec.code)
+        pending[(rec.tool, scope)].append(rec.code)
 
 
 def audit(root: str, server: str, samples: int, filters: "Filters | None" = None):
@@ -591,7 +608,7 @@ def to_json(result) -> str:
     codes = {
         code: {
             "count": s.count,
-            "sessions": len(s.sessions),
+            "sessions": s.session_count(),
             "recovered": s.recovered,
             "retryable": s.retryable,
             "first_seen": s.first_seen,
@@ -701,7 +718,7 @@ def to_text(result) -> str:
         first = (s.first_seen or "?")[:10]
         last = (s.last_seen or "?")[:10]
         out.append(
-            f"{code:<34} {s.count:>5} {len(s.sessions):>4} {s.recovered:>5} "
+            f"{code:<34} {s.count:>5} {s.session_count():>4} {s.recovered:>5} "
             f"{retry:>5}  {first:<10}  {last:<10}  {tools}"
         )
         if s.repair:

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -511,9 +511,16 @@ class Filters:
         return ", ".join(parts)
 
     def selects(self, rec: CallRecord, coverage: Coverage) -> bool:
-        if self.unknown == "exclude" and rec.unknown_reason:
+        # ONE definition of unknown, and it is the same one Coverage uses: does this call
+        # carry a value for the dimension we are grouping by? Testing rec.unknown_reason
+        # instead ("was there any envelope at all?") is dimension-INdependent, and the two
+        # diverge on the whole fingerprint-only corpus that exists today: `exclude` became
+        # a silent no-op, and `only` returned nothing while coverage reported those very
+        # calls as unattributed.
+        unattributed = rec.scope(self.group_by) == UNKNOWN
+        if self.unknown == "exclude" and unattributed:
             return False
-        if self.unknown == "only" and not rec.unknown_reason:
+        if self.unknown == "only" and not unattributed:
             return False
         if self.server_version and rec.version != self.server_version:
             return False

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -588,7 +588,15 @@ def aggregate(
         if not rec.is_error:
             for (tool, pend_scope) in [k for k in pending if k[0] == rec.tool]:
                 for code in pending.pop((tool, pend_scope)):
-                    if pend_scope == scope:
+                    # Recovery requires BOTH ends to be attributed to the SAME scope.
+                    # UNKNOWN is not a scope that can equal itself: two calls that each
+                    # carry no version may well be from different releases, so a success
+                    # at an unknown scope is evidence of nothing, and an error at an
+                    # unknown scope is recovered by nothing. Report those as
+                    # indeterminate. Comparing pend_scope == scope alone made unknown ==
+                    # unknown true and quietly restored the old unscoped semantics —
+                    # across the entire corpus, where no call carries a version yet.
+                    if scope != UNKNOWN and pend_scope == scope:
                         codes[code].recovered += 1
                     else:
                         codes[code].cross_version_success += 1

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -453,6 +453,13 @@ class ServerStat:
 
 @dataclass
 class Coverage:
+    """Attribution is relative to the ACTIVE `Filters.group_by` dimension: a call
+    that carries a fingerprint but no server_version is unattributed when grouping
+    by version, even though it has a perfectly well-formed envelope — and vice
+    versa. This is deliberately NOT the same thing as `CallRecord.unknown_reason`,
+    which asks only "was there a usable envelope at all," independent of which
+    dimension the report is currently keyed by."""
+
     total_calls: int = 0
     attributed_calls: int = 0
     unknown: collections.Counter = field(default_factory=collections.Counter)
@@ -477,6 +484,24 @@ class Filters:
 
     def date_scoped(self) -> bool:
         return bool(self.since or self.until)
+
+    def describe_active(self) -> str:
+        """Human-readable list of the scope filters currently narrowing results.
+
+        Empty when every filter is at its default (nothing is being scoped).
+        """
+        parts = []
+        if self.server_version:
+            parts.append(f"server-version {self.server_version}")
+        if self.fingerprint:
+            parts.append(f"fingerprint {self.fingerprint}")
+        if self.since:
+            parts.append(f"since {self.since}")
+        if self.until:
+            parts.append(f"until {self.until}")
+        if self.unknown != "include":
+            parts.append(f"unknown={self.unknown}")
+        return ", ".join(parts)
 
     def selects(self, rec: CallRecord, coverage: Coverage) -> bool:
         if self.unknown == "exclude" and rec.unknown_reason:
@@ -527,10 +552,17 @@ def aggregate(
         total_calls[rec.tool] += 1
         audit_sessions.add(rec.session)
         coverage.total_calls += 1
-        if rec.unknown_reason:
-            coverage.unknown[rec.unknown_reason] += 1
-        else:
+        # Attribution is judged against filters.group_by, the ACTIVE dimension — not
+        # against whether the record has ANY identity at all. A call with only a
+        # fingerprint is not attributed when the matrix and header are keyed by
+        # version. rec.unknown_reason stays dimension-independent ("was there a
+        # usable envelope at all"); when this dimension's own value is simply
+        # absent from an otherwise-fine envelope, that reason is "not_emitted"
+        # here even if rec.unknown_reason is None (some OTHER dimension was set).
+        if scope != UNKNOWN:
             coverage.attributed_calls += 1
+        else:
+            coverage.unknown[rec.unknown_reason or "not_emitted"] += 1
 
         if rec.unknown_reason == "no_result":
             continue  # never answered: nothing to classify or recover
@@ -572,6 +604,9 @@ def audit(root: str, server: str, samples: int, filters: "Filters | None" = None
     codes: dict[str, CodeStat] = collections.defaultdict(CodeStat)
     audit_sessions: set[str] = set()
     coverage = Coverage()
+    # Calls that matched the server, BEFORE filters.selects() scopes them down — lets
+    # the report tell "no such server" apart from "the filters excluded everything".
+    raw_matched_calls = 0
 
     for path in files:
         records = records_for_file(path, root)
@@ -591,6 +626,7 @@ def audit(root: str, server: str, samples: int, filters: "Filters | None" = None
             continue
 
         matched = [r for r in records if needle in r.server.lower()]
+        raw_matched_calls += len(matched)
         selected = [r for r in matched if filters.selects(r, coverage)]
         aggregate(selected, filters, samples, codes, total_calls, total_errors,
                   audit_sessions, coverage)
@@ -607,6 +643,7 @@ def audit(root: str, server: str, samples: int, filters: "Filters | None" = None
         "codes": codes,
         "coverage": coverage,
         "filters": filters,
+        "raw_matched_calls": raw_matched_calls,
     }
 
 
@@ -731,10 +768,22 @@ def to_text(result) -> str:
     n_sess = len(result["audit_sessions"])
     out.append(f"# MCP error audit — servers matching '{result['server']}'")
     if not calls:
-        out.append(
-            "\nNo MCP tool calls matched. Run without --server to list "
-            "the servers seen in transcripts."
-        )
+        raw = result.get("raw_matched_calls", 0)
+        if raw:
+            # The server matched calls; the active scope filters excluded all of
+            # them. Say so and name the filters — conflating this with "no such
+            # server" sends the user to fix the wrong thing.
+            desc = result["filters"].describe_active() or "the active filters"
+            out.append(
+                f"\nmatched {raw} calls for this server, but 0 after scoping to "
+                f"{desc}. Loosen or drop --server-version/--fingerprint/--since/"
+                "--until/--unknown to see them."
+            )
+        else:
+            out.append(
+                "\nNo MCP tool calls matched. Run without --server to list "
+                "the servers seen in transcripts."
+            )
         return "\n".join(out)
     out.append(f"matched: {', '.join(result['matched_servers'])}")
     distinct = distinct_matches(result)

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -309,25 +309,40 @@ def records_for_file(path: str, root: str) -> list[CallRecord]:
     """
     session = session_key(path, root)
     calls: dict[str, CallRecord] = {}
+    no_id_calls: list[CallRecord] = []
     for rec in iter_records(path):
         ts = record_ts(rec)
         for item in message_content(rec):
             if not (isinstance(item, dict) and item.get("type") == "tool_use"):
                 continue
             parsed = parse_tool_name(item.get("name") or "")
-            tid = item.get("id")
-            if not parsed or not tid:
+            if not parsed:
                 continue
             server, tool = parsed
             raw = json.dumps(item.get("input", {}), sort_keys=True, default=str)
-            calls[tid] = CallRecord(
-                input_id=tid,
-                server=server,
-                tool=tool,
-                session=session,
-                ts=ts,
-                input=" ".join(raw.split())[:120],
-            )
+            tid = item.get("id")
+            if tid:
+                calls[tid] = CallRecord(
+                    input_id=tid,
+                    server=server,
+                    tool=tool,
+                    session=session,
+                    ts=ts,
+                    input=" ".join(raw.split())[:120],
+                )
+            else:
+                # Tool use with valid name but no id: record as no_result
+                no_id_calls.append(
+                    CallRecord(
+                        input_id="",
+                        server=server,
+                        tool=tool,
+                        session=session,
+                        ts=ts,
+                        input=" ".join(raw.split())[:120],
+                        unknown_reason="no_result",
+                    )
+                )
 
     ordered: list[CallRecord] = []
     for rec in iter_records(path):
@@ -356,6 +371,9 @@ def records_for_file(path: str, root: str) -> list[CallRecord]:
     for call in calls.values():
         call.unknown_reason = "no_result"
         ordered.append(call)
+
+    # Append calls that had no id (they can never be paired with results)
+    ordered.extend(no_id_calls)
     return ordered
 
 

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -809,7 +809,10 @@ def to_text(result) -> str:
 
     calls = sum(result["total_calls"].values())
     errors = sum(result["total_errors"].values())
-    rate = f"{100 * errors / calls:.1f}%" if calls else "n/a"
+    # This rate spans EVERY matched call, attributed or not. That is a legitimate
+    # figure — but it belongs to no single release, so it is labeled as what it is.
+    # The per-release rates live in the matrix, each over its own denominator.
+    rate = f"{100 * errors / calls:.1f}% of all matched calls, attributed or not" if calls else "n/a"
     n_sess = len(result["audit_sessions"])
     out.append(f"# MCP error audit — servers matching '{result['server']}'")
     if not calls:
@@ -852,9 +855,16 @@ def to_text(result) -> str:
         + (f" · unattributed: {dict(cov.unknown)}" if cov.unknown else "")
     )
     if cov.partial():
+        # Say exactly what the report computes. The previous wording claimed every rate
+        # below was attributed-only while the sole rate printed was errors/ALL calls —
+        # and no per-scope rate existed at all.
+        unattributed = sum(cov.unknown.values())
         out.append(
-            "NOTE: rates below are PARTIAL — computed over attributed calls only, "
-            "because some calls carry no version. They are not error rates over all calls."
+            f"NOTE: PARTIAL — {unattributed} calls could not be attributed to a {dim}. "
+            f"Each {dim} column in the matrix below has its own denominator (its `calls` "
+            f"row), so no release's rate borrows another's calls; the unattributable ones "
+            "are isolated in the `unknown` column instead of inflating any release. The "
+            "overall rate in the header spans all matched calls, attributed or not."
         )
     if result["filters"].date_scoped():
         out.append(

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -996,13 +996,26 @@ def parse_argv(argv) -> argparse.Namespace:
     args = parser.parse_args(argv)
 
     if args.args_string is not None:
-        # Defense-in-depth at the PYTHON layer only: rejecting quotes here keeps a
-        # stray quote from producing a confusing shlex parse. It does NOT and cannot
-        # prevent shell injection: bash tokenizes the interpolated $ARGUMENTS before
-        # this script ever runs, so anything that breaks out of the shell quoting in
-        # commands/mcp-error-audit.md has already happened by the time we see argv.
-        # The `allowed-tools` allowlist in that command file is what guards the shell
-        # layer.
+        # KNOWN, ACCEPTED RISK — SHELL INJECTION. commands/mcp-error-audit.md interpolates
+        # $ARGUMENTS into a shell string (`--args '$ARGUMENTS'`). A payload that closes the
+        # quote runs arbitrary commands:
+        #
+        #     /mcp-error-audit x' ; echo pwned #
+        #     → python3 ... --args 'x' ; echo pwned #'      (bash runs `echo pwned`)
+        #
+        # The quote rejection BELOW DOES NOT PREVENT THIS, and cannot: bash tokenizes the
+        # string before Python starts, so Python receives argv ['--args', 'x'] — no quote
+        # ever reaches this check. It is bypassed, not defeated. Its only real job is to
+        # keep a stray quote from producing a confusing shlex parse.
+        #
+        # `allowed-tools` DOES NOT GUARD THIS EITHER: `Bash(python3 …/mcp_error_audit.py:*)`
+        # is a PREFIX match, and the injected string still begins with the allowed prefix,
+        # so it matches and runs. (An earlier version of this comment claimed the allowlist
+        # was the guard. It is not; that claim was false.)
+        #
+        # The risk predates version scoping and is knowingly accepted: the only caller is
+        # the user's own slash command, typed by the user, in the user's own shell. Actually
+        # closing it means not interpolating $ARGUMENTS into a shell string at all.
         if "'" in args.args_string or '"' in args.args_string:
             parser.error("quotes are not allowed in the command arguments")
         try:

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -272,6 +272,94 @@ def session_key(path: str, root: str) -> str:
 
 
 @dataclass
+class CallRecord:
+    """One MCP tool call and its outcome.
+
+    Attribution (`version`/`fingerprint`, or `unknown_reason`) and classification
+    (`is_error`/`code`) are INDEPENDENT: a call whose release cannot be attributed may
+    still be a real error, and is still counted as one.
+    """
+
+    input_id: str
+    server: str
+    tool: str
+    session: str
+    ts: str | None
+    input: str
+    text: str = ""
+    version: str | None = None
+    fingerprint: str | None = None
+    unknown_reason: str | None = None
+    is_error: bool = False
+    code: str | None = None
+    retryable: bool | None = None
+    repair: str | None = None
+
+    def scope(self, group_by: str) -> str:
+        """This call's bucket under the chosen dimension; UNKNOWN when unattributed."""
+        value = self.fingerprint if group_by == "fingerprint" else self.version
+        return value or UNKNOWN
+
+
+def records_for_file(path: str, root: str) -> list[CallRecord]:
+    """Every MCP call in one transcript, in RESULT order, unpaired calls last.
+
+    Result order (not call order) is what recovery reasons about: an error "recovers"
+    when a later RESULT for the same tool succeeds.
+    """
+    session = session_key(path, root)
+    calls: dict[str, CallRecord] = {}
+    for rec in iter_records(path):
+        ts = record_ts(rec)
+        for item in message_content(rec):
+            if not (isinstance(item, dict) and item.get("type") == "tool_use"):
+                continue
+            parsed = parse_tool_name(item.get("name") or "")
+            tid = item.get("id")
+            if not parsed or not tid:
+                continue
+            server, tool = parsed
+            raw = json.dumps(item.get("input", {}), sort_keys=True, default=str)
+            calls[tid] = CallRecord(
+                input_id=tid,
+                server=server,
+                tool=tool,
+                session=session,
+                ts=ts,
+                input=" ".join(raw.split())[:120],
+            )
+
+    ordered: list[CallRecord] = []
+    for rec in iter_records(path):
+        for item in message_content(rec):
+            if not (isinstance(item, dict) and item.get("type") == "tool_result"):
+                continue
+            call = calls.pop(item.get("tool_use_id") or "", None)
+            if call is None:
+                continue
+            text = result_text(item)
+            obj = parse_envelope(text)
+            call.text = text
+            call.is_error = is_error_result(item, obj)
+            if call.is_error:
+                call.code, call.retryable, call.repair = classify(text, obj)
+            if not isinstance(obj, dict):
+                call.unknown_reason = "unparseable_result"
+            else:
+                call.version = extract_version(obj)
+                call.fingerprint = extract_fingerprint(obj)
+                if call.version is None and call.fingerprint is None:
+                    call.unknown_reason = "not_emitted"
+            ordered.append(call)
+
+    # Calls never answered: no result to attribute from, and no outcome to classify.
+    for call in calls.values():
+        call.unknown_reason = "no_result"
+        ordered.append(call)
+    return ordered
+
+
+@dataclass
 class CodeStat:
     count: int = 0
     recovered: int = 0
@@ -321,7 +409,82 @@ class ServerStat:
     last_call: str | None = None
 
 
-def audit(root: str, server: str, samples: int):
+@dataclass
+class Coverage:
+    total_calls: int = 0
+    attributed_calls: int = 0
+    unknown: collections.Counter = field(default_factory=collections.Counter)
+
+    def partial(self) -> bool:
+        """True when some calls could not be attributed — every rate is then partial."""
+        return sum(self.unknown.values()) > 0
+
+
+@dataclass
+class Filters:
+    server_version: str | None = None
+    fingerprint: str | None = None
+    since: str | None = None
+    until: str | None = None
+    group_by: str = "version"
+    unknown: str = "include"
+
+    def selects(self, rec: CallRecord, coverage: Coverage) -> bool:
+        return True
+
+
+def aggregate(
+    records: list[CallRecord],
+    filters: Filters,
+    samples: int,
+    codes: dict[str, "CodeStat"],
+    total_calls: collections.Counter,
+    total_errors: collections.Counter,
+    audit_sessions: set[str],
+    coverage: Coverage,
+) -> None:
+    """Fold one transcript's selected call records into the running totals.
+
+    Recovery is scoped per file: a later SUCCESS for the same tool retires the codes
+    still `pending` for that tool. Records must arrive in the RESULT order
+    `records_for_file` returns (unpaired calls last) so recovery sees results in the
+    order they actually landed, and unanswered calls never masquerade as a success.
+    """
+    pending: dict[str, list[str]] = collections.defaultdict(list)
+    for rec in records:
+        total_calls[rec.tool] += 1
+        audit_sessions.add(rec.session)
+        coverage.total_calls += 1
+        if rec.unknown_reason is None:
+            coverage.attributed_calls += 1
+        else:
+            coverage.unknown[rec.unknown_reason] += 1
+
+        if rec.unknown_reason == "no_result":
+            continue  # never answered: nothing to classify or recover
+
+        if not rec.is_error:
+            for code in pending.pop(rec.tool, []):
+                codes[code].recovered += 1
+            continue
+
+        total_errors[rec.tool] += 1
+        assert rec.code is not None  # classify() always sets code when is_error is True
+        stat = codes[rec.code]
+        stat.count += 1
+        stat.sessions.add(rec.session)
+        stat.tools[rec.tool] += 1
+        if stat.see(rec.ts):
+            if rec.retryable is not None:
+                stat.retryable = rec.retryable
+            if rec.repair:
+                stat.repair = rec.repair
+        stat.add_sample(rec.ts, rec.input, rec.text, samples)
+        pending[rec.tool].append(rec.code)
+
+
+def audit(root: str, server: str, samples: int, filters: "Filters | None" = None):
+    filters = filters or Filters()
     files = sorted(glob(os.path.join(root, "**", "*.jsonl"), recursive=True))
     all_sessions = {session_key(p, root) for p in files}
     needle = server.lower()
@@ -331,76 +494,29 @@ def audit(root: str, server: str, samples: int):
     total_errors = collections.Counter()
     codes: dict[str, CodeStat] = collections.defaultdict(CodeStat)
     audit_sessions: set[str] = set()
+    coverage = Coverage()
 
     for path in files:
-        session = session_key(path, root)
+        records = records_for_file(path, root)
 
-        id2parsed: dict[str, tuple[str, str]] = {}
-        id2input: dict[str, str] = {}
-        for rec in iter_records(path):
-            ts = record_ts(rec)
-            for item in message_content(rec):
-                if not (isinstance(item, dict) and item.get("type") == "tool_use"):
-                    continue
-                parsed = parse_tool_name(item.get("name") or "")
-                if not parsed:
-                    continue
-                tid = item.get("id")
-                if tid:
-                    id2parsed[tid] = parsed
-                srv, tool = parsed
-                sstat = servers[srv]
-                sstat.calls += 1
-                sstat.sessions.add(session)
-                if ts and (sstat.last_call is None or ts > sstat.last_call):
-                    sstat.last_call = ts
-                if needle and needle in srv.lower():
-                    total_calls[tool] += 1
-                    audit_sessions.add(session)
-                    if tid:
-                        raw = json.dumps(
-                            item.get("input", {}), sort_keys=True, default=str
-                        )
-                        id2input[tid] = " ".join(raw.split())[:120]
+        # Discovery-mode stats cover EVERY server and are deliberately unfiltered and
+        # unversioned: they keep their all-call denominator (see the spec).
+        for rec in records:
+            sstat = servers[rec.server]
+            sstat.calls += 1
+            sstat.sessions.add(rec.session)
+            if rec.is_error:
+                sstat.errors += 1
+            if rec.ts and (sstat.last_call is None or rec.ts > sstat.last_call):
+                sstat.last_call = rec.ts
 
-        # An error "recovers" when a later result for the same tool in the
-        # same transcript succeeds; pending holds codes awaiting that success.
-        pending: dict[str, list[str]] = collections.defaultdict(list)
-        for rec in iter_records(path):
-            ts = record_ts(rec)
-            for item in message_content(rec):
-                if not (isinstance(item, dict) and item.get("type") == "tool_result"):
-                    continue
-                parsed = id2parsed.get(item.get("tool_use_id") or "")
-                if not parsed:
-                    continue
-                srv, tool = parsed
-                text = result_text(item)
-                obj = parse_envelope(text)
-                err = is_error_result(item, obj)
-                if err:
-                    servers[srv].errors += 1
-                if not (needle and needle in srv.lower()):
-                    continue
-                if not err:
-                    for code in pending.pop(tool, []):
-                        codes[code].recovered += 1
-                    continue
-                total_errors[tool] += 1
-                code, retryable, repair = classify(text, obj)
-                stat = codes[code]
-                stat.count += 1
-                stat.sessions.add(session)
-                stat.tools[tool] += 1
-                if stat.see(ts):
-                    if retryable is not None:
-                        stat.retryable = retryable
-                    if repair:
-                        stat.repair = repair
-                stat.add_sample(
-                    ts, id2input.get(item.get("tool_use_id") or "", "?"), text, samples
-                )
-                pending[tool].append(code)
+        if not needle:
+            continue
+
+        matched = [r for r in records if needle in r.server.lower()]
+        selected = [r for r in matched if filters.selects(r, coverage)]
+        aggregate(selected, filters, samples, codes, total_calls, total_errors,
+                  audit_sessions, coverage)
 
     return {
         "server": server,
@@ -412,6 +528,8 @@ def audit(root: str, server: str, samples: int):
         "total_calls": total_calls,
         "total_errors": total_errors,
         "codes": codes,
+        "coverage": coverage,
+        "filters": filters,
     }
 
 

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -463,6 +463,13 @@ class Coverage:
     total_calls: int = 0
     attributed_calls: int = 0
     unknown: collections.Counter = field(default_factory=collections.Counter)
+    # CALLS (not errors) per scope — the only honest denominator for a per-scope rate,
+    # and the N in "not observed in 0.10.0 over N attributed calls". Errors alone cannot
+    # supply it: a release with zero errors has no error rows at all, yet it is exactly
+    # the release the user is running and asking about. Includes an UNKNOWN key when
+    # some selected calls could not be attributed, so the buckets sum to every call
+    # aggregate() saw.
+    calls_by_scope: collections.Counter = field(default_factory=collections.Counter)
 
     def partial(self) -> bool:
         """True when some calls could not be attributed — every rate is then partial."""
@@ -552,6 +559,10 @@ def aggregate(
         total_calls[rec.tool] += 1
         audit_sessions.add(rec.session)
         coverage.total_calls += 1
+        # Count the CALL against its scope, whether or not it errored. A clean release
+        # must still get a column (and a denominator) — otherwise the release with no
+        # errors yet is invisible in the report.
+        coverage.calls_by_scope[scope] += 1
         # Attribution is judged against filters.group_by, the ACTIVE dimension — not
         # against whether the record has ANY identity at all. A call with only a
         # fingerprint is not attributed when the matrix and header are keyed by
@@ -651,6 +662,36 @@ def sorted_codes(result):
     return sorted(result["codes"].items(), key=lambda kv: -kv[1].count)
 
 
+def errors_by_scope(result) -> collections.Counter:
+    """Errors per scope — the numerator whose denominator is coverage.calls_by_scope."""
+    total = collections.Counter()
+    for stat in result["codes"].values():
+        total.update(stat.by_scope)
+    return total
+
+
+def matrix_scopes(result) -> list[str]:
+    """The matrix's columns, derived from CALL scopes — not error scopes.
+
+    A release whose calls all succeeded has no error rows, but it still gets a column
+    (all zeros, over a real call denominator). The error scopes are unioned in purely
+    defensively; they are a subset of the call scopes by construction. UNKNOWN sorts
+    last so observed releases read left-to-right.
+    """
+    scopes = set(result["coverage"].calls_by_scope) | {
+        sc for stat in result["codes"].values() for sc in stat.by_scope
+    }
+    return sorted(scopes, key=lambda sc: (sc == UNKNOWN, sc))
+
+
+def scope_rate(result, scope: str) -> str:
+    """One scope's error rate, over THAT scope's own calls. Never a global denominator."""
+    calls = result["coverage"].calls_by_scope.get(scope, 0)
+    if not calls:
+        return "n/a"
+    return f"{100 * errors_by_scope(result).get(scope, 0) / calls:.1f}%"
+
+
 def matched_last_call(result) -> str | None:
     """Newest call timestamp across the matched servers, for staleness anchoring."""
     stamps = [
@@ -731,6 +772,10 @@ def to_json(result) -> str:
                 "partial": result["coverage"].partial(),
                 "group_by": result["filters"].group_by,
                 "date_scoped": result["filters"].date_scoped(),
+                # Per-scope CALL denominators and their matching numerators. A consumer
+                # can compute any per-scope rate without ever reaching for a global count.
+                "calls_by_scope": dict(result["coverage"].calls_by_scope),
+                "errors_by_scope": dict(errors_by_scope(result)),
             },
         },
         indent=2,
@@ -818,13 +863,14 @@ def to_text(result) -> str:
             "--server-version or --fingerprint, which are observed in the envelope."
         )
 
-    scopes = sorted({sc for s in result["codes"].values() for sc in s.by_scope})
+    scopes = matrix_scopes(result)
     if scopes:
         # Column width follows the widest scope label (version strings are short;
         # fingerprints like "codex-in-claude/0.1/schema-38" are not) so headers and
         # data stay aligned instead of running together. MIN_SCOPE_COL keeps narrow
         # counts from crowding a short label like "1.0.0".
         col_width = max(MIN_SCOPE_COL, max(len(sc) for sc in scopes))
+        errs = errors_by_scope(result)
         out.append(f"\n## Errors by code × {dim}")
         header = f"{'code':<34}" + "".join(f" {sc:>{col_width}}" for sc in scopes)
         out.append(header)
@@ -833,10 +879,24 @@ def to_text(result) -> str:
                 f" {s.by_scope.get(sc, 0):>{col_width}}" for sc in scopes
             )
             out.append(row)
+        out.append("-" * 34 + "".join(" " + "-" * col_width for _ in scopes))
+        # Each column's OWN denominator. Without it the report could only offer the
+        # global call count, and pinning a cross-release denominator to one release
+        # is precisely the lying statistic this tool refuses to print.
         out.append(
-            "\nA zero above means NOT OBSERVED in that "
-            f"{dim} over the attributed calls shown — not a fix. This tool reads "
-            "transcripts; it cannot see a code change."
+            f"{'calls':<34}"
+            + "".join(
+                f" {cov.calls_by_scope.get(sc, 0):>{col_width}}" for sc in scopes
+            )
+        )
+        out.append(f"{'err%':<34}" + "".join(f" {scope_rate(result, sc):>{col_width}}" for sc in scopes))
+        out.append(
+            f"\ncalls = calls observed at that {dim}; it is the denominator for that "
+            f"column's err% — no other {dim}'s calls are mixed in. In the `unknown` "
+            f"column those calls carry no {dim} in their own result.\n"
+            f"A zero in a code's row means NOT OBSERVED in that {dim} over that "
+            "column's calls — not a fix. This tool reads transcripts; it cannot see a "
+            "code change."
         )
 
     out.append("\n## Per-tool")

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -637,10 +637,12 @@ def to_json(result) -> str:
             "count": s.count,
             "sessions": s.session_count(),
             "recovered": s.recovered,
+            "cross_version_success": s.cross_version_success,
             "retryable": s.retryable,
             "first_seen": s.first_seen,
             "last_seen": s.last_seen,
             "tools": dict(s.tools),
+            "by_scope": dict(s.by_scope),
             "repair": s.repair,
             "samples": s.samples,
         }
@@ -670,6 +672,14 @@ def to_json(result) -> str:
                 for t in result["total_calls"]
             },
             "by_code": codes,
+            "coverage": {
+                "total_calls": result["coverage"].total_calls,
+                "attributed_calls": result["coverage"].attributed_calls,
+                "unknown": dict(result["coverage"].unknown),
+                "partial": result["coverage"].partial(),
+                "group_by": result["filters"].group_by,
+                "date_scoped": result["filters"].date_scoped(),
+            },
         },
         indent=2,
     )
@@ -725,6 +735,39 @@ def to_text(result) -> str:
         f"last call {(matched_last_call(result) or '?')[:10]}"
     )
 
+    cov = result["coverage"]
+    dim = result["filters"].group_by
+    attributed = cov.attributed_calls
+    out.append(
+        f"coverage: {attributed}/{cov.total_calls} calls attributed to a {dim}"
+        + (f" · unattributed: {dict(cov.unknown)}" if cov.unknown else "")
+    )
+    if cov.partial():
+        out.append(
+            "NOTE: rates below are PARTIAL — computed over attributed calls only, "
+            "because some calls carry no version. They are not error rates over all calls."
+        )
+    if result["filters"].date_scoped():
+        out.append(
+            "NOTE: date-scoped, APPROXIMATE — a date is a proxy for a release. It is wrong "
+            "if you upgraded late or ran a dev tree between releases. Prefer "
+            "--server-version or --fingerprint, which are observed in the envelope."
+        )
+
+    scopes = sorted({sc for s in result["codes"].values() for sc in s.by_scope})
+    if scopes:
+        out.append(f"\n## Errors by code × {dim}")
+        header = f"{'code':<34}" + "".join(f"{sc:>14}" for sc in scopes)
+        out.append(header)
+        for code, s in sorted_codes(result):
+            row = f"{code:<34}" + "".join(f"{s.by_scope.get(sc, 0):>14}" for sc in scopes)
+            out.append(row)
+        out.append(
+            "\nA zero above means NOT OBSERVED in that "
+            f"{dim} over the attributed calls shown — not a fix. This tool reads "
+            "transcripts; it cannot see a code change."
+        )
+
     out.append("\n## Per-tool")
     out.append(f"{'tool':<28} {'calls':>6} {'errs':>6}")
     for tool, n in result["total_calls"].most_common():
@@ -733,10 +776,12 @@ def to_text(result) -> str:
     out.append(
         f"\n## Errors by code  (sess = distinct sessions out of the {n_sess} "
         "that called this server; recov = errors followed later in the same "
-        "transcript by a success of the same tool)"
+        "transcript by a success of the same tool AND scope; cross = followed "
+        "instead by a success at a different/unknown scope — indeterminate, "
+        "not recovery)"
     )
     out.append(
-        f"{'code':<34} {'count':>5} {'sess':>4} {'recov':>5} {'retry':>5}  "
+        f"{'code':<34} {'count':>5} {'sess':>4} {'recov':>5} {'cross':>5} {'retry':>5}  "
         f"{'first_seen':<10}  {'last_seen':<10}  tools"
     )
     for code, s in sorted_codes(result):
@@ -746,7 +791,7 @@ def to_text(result) -> str:
         last = (s.last_seen or "?")[:10]
         out.append(
             f"{code:<34} {s.count:>5} {s.session_count():>4} {s.recovered:>5} "
-            f"{retry:>5}  {first:<10}  {last:<10}  {tools}"
+            f"{s.cross_version_success:>5} {retry:>5}  {first:<10}  {last:<10}  {tools}"
         )
         if s.repair:
             out.append(f"    repair: {s.repair}")

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -476,6 +476,7 @@ class Filters:
             # The CALL's start time, never the result's: filtering the two records
             # independently would split a pair and manufacture phantom no_result calls.
             if not rec.ts:
+                coverage.total_calls += 1
                 coverage.unknown["missing_timestamp"] += 1
                 return False
             day = rec.ts[:10]

--- a/plugins/mcp-error-audit/scripts/mcp_error_audit.py
+++ b/plugins/mcp-error-audit/scripts/mcp_error_audit.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import collections
+import datetime
 import json
 import os
 import re
@@ -299,8 +300,16 @@ class CallRecord:
     server: str
     tool: str
     session: str
+    # The CALL's start time. Used ONLY for --since/--until: filtering the tool_use and
+    # tool_result records independently would split a pair and manufacture phantom
+    # no_result calls. It is NOT the error's occurrence time — see result_ts.
     ts: str | None
     input: str
+    # The paired RESULT's time: when the error actually landed. first_seen/last_seen,
+    # `repair`/`retryable` recency, and the sample dates are all occurrence facts and
+    # must read this, not ts. None until the call is paired (and for calls never
+    # answered, which carry no outcome to date anyway).
+    result_ts: str | None = None
     text: str = ""
     version: str | None = None
     fingerprint: str | None = None
@@ -369,6 +378,7 @@ def records_for_file(path: str, root: str) -> list[CallRecord]:
                 continue
             text = result_text(item)
             obj = parse_envelope(text)
+            call.result_ts = record_ts(rec)
             call.text = text
             call.is_error = is_error_result(item, obj)
             if call.is_error:
@@ -620,12 +630,15 @@ def aggregate(
         stat.sessions.add((scope, rec.session))
         stat.by_scope[scope] += 1
         stat.tools[rec.tool] += 1
-        if stat.see(rec.ts):
+        # Occurrence time is the RESULT's, never the call's start: an error happened when
+        # it came back. Only --since/--until reads rec.ts, and only to keep a call and its
+        # result on the same side of the window.
+        if stat.see(rec.result_ts):
             if rec.retryable is not None:
                 stat.retryable = rec.retryable
             if rec.repair:
                 stat.repair = rec.repair
-        stat.add_sample(rec.ts, rec.input, rec.text, samples)
+        stat.add_sample(rec.result_ts, rec.input, rec.text, samples)
         pending[(rec.tool, scope)].append(rec.code)
 
 
@@ -702,12 +715,16 @@ _NUMERIC_RUN = re.compile(r"(\d+)")
 def natural_sort_key(s: str) -> list[tuple[int, object]]:
     """Split `s` into text/number chunks so numeric runs compare BY VALUE.
 
-    A plain string sort puts "0.10.0" before "0.9.0" and "schema-10" before
-    "schema-2" — wrong for both version numbers and fingerprint schema ids, whose
-    whole point is to read as a trajectory toward the newest release. Each chunk is
-    tagged (0, str) or (1, int) so chunks of different types never get compared
+    A plain string sort puts "0.10.0" before "0.9.0" and "schema-10" before "schema-2",
+    which makes both version numbers and fingerprint schema ids hard to scan. Each chunk
+    is tagged (0, str) or (1, int) so chunks of different types never get compared
     directly against each other (which would raise); only same-position, same-type
     chunks are ever compared, and the tag alone breaks ties across types.
+
+    This is READABILITY, NOT CHRONOLOGY. It is not semver-aware: "1.0.0" sorts before
+    "1.0.0-rc1" (the prerelease lands to the RIGHT of the release it preceded), and a
+    mixed "v2.0.0"/"2.0.0" corpus orders by chunk type, not by release. Do not read
+    column order as a release timeline.
     """
     chunks = [c for c in _NUMERIC_RUN.split(s) if c != ""]
     return [(1, int(c)) if c.isdigit() else (0, c) for c in chunks]
@@ -719,9 +736,10 @@ def matrix_scopes(result) -> list[str]:
     A release whose calls all succeeded has no error rows, but it still gets a column
     (all zeros, over a real call denominator). The error scopes are unioned in purely
     defensively; they are a subset of the call scopes by construction. UNKNOWN sorts
-    last; the rest sort in natural (numeric-aware) order so observed releases read
-    left-to-right toward the newest one — "0.9.0" before "0.10.0", "schema-3" before
-    "schema-10" — instead of a lexicographic sort that would put them backwards.
+    last; the rest sort in natural (numeric-aware) order, so labels like "0.9.0"/"0.10.0"
+    and "schema-3"/"schema-10" are easier to scan than under a lexicographic sort. That
+    order does NOT establish release chronology — see natural_sort_key: prereleases and
+    mixed version prefixes land wherever the chunk comparison puts them.
     """
     scopes = set(result["coverage"].calls_by_scope) | {
         sc for stat in result["codes"].values() for sc in stat.by_scope
@@ -818,6 +836,19 @@ def to_json(result) -> str:
                 "partial": result["coverage"].partial(),
                 "group_by": result["filters"].group_by,
                 "date_scoped": result["filters"].date_scoped(),
+                # Every number above is scoped by these. Serialize them, or a consumer
+                # holding the JSON cannot tell WHICH population it is looking at:
+                # `date_scoped: true` alone loses the window, and a combined
+                # version/fingerprint/unknown scope is unreconstructable. A scoped
+                # statistic whose scope is not stated is the same failure as a
+                # denominator that is not named.
+                "active_filters": {
+                    "server_version": result["filters"].server_version,
+                    "fingerprint": result["filters"].fingerprint,
+                    "since": result["filters"].since,
+                    "until": result["filters"].until,
+                    "unknown": result["filters"].unknown,
+                },
                 # Per-scope CALL denominators and their matching numerators. A consumer
                 # can compute any per-scope rate without ever reaching for a global count.
                 "calls_by_scope": dict(result["coverage"].calls_by_scope),
@@ -940,11 +971,22 @@ def to_text(result) -> str:
 
     scopes = matrix_scopes(result)
     if scopes:
-        # Column width follows the widest scope label (version strings are short;
-        # fingerprints like "codex-in-claude/0.1/schema-38" are not) so headers and
-        # data stay aligned instead of running together. MIN_SCOPE_COL keeps narrow
-        # counts from crowding a short label like "1.0.0".
-        col_width = max(MIN_SCOPE_COL, max(len(sc) for sc in scopes))
+        # Width follows the widest thing that will actually be PRINTED in the column, not
+        # just the scope label (version strings are short; fingerprints like
+        # "codex-in-claude/0.1/schema-38" are not). A cell wider than col_width silently
+        # expands past the format spec and knocks that one row out of alignment with the
+        # header — so the counts and rates have to be measured too, not assumed narrower.
+        # MIN_SCOPE_COL keeps narrow counts from crowding a short label like "1.0.0".
+        cells = [
+            str(s.by_scope.get(sc, 0)) for _c, s in sorted_codes(result) for sc in scopes
+        ]
+        cells += [str(cov.calls_by_scope.get(sc, 0)) for sc in scopes]
+        cells += [scope_rate(result, sc) for sc in scopes]
+        col_width = max(
+            MIN_SCOPE_COL,
+            max(len(sc) for sc in scopes),
+            max((len(c) for c in cells), default=0),
+        )
         out.append(f"\n## Errors by code × {dim}")
         header = f"{'code':<34}" + "".join(f" {sc:>{col_width}}" for sc in scopes)
         out.append(header)
@@ -1085,20 +1127,41 @@ def parse_argv(argv) -> argparse.Namespace:
         parser.error(f"invalid --server-version {args.server_version!r}")
     if args.fingerprint and not VALID_FINGERPRINT.match(args.fingerprint):
         parser.error(f"invalid --fingerprint {args.fingerprint!r}")
+    # Shape alone is not enough: `2026-02-31` matches the regex and is not a date. Parse
+    # a real calendar date, and reject an inverted window — both otherwise sail through
+    # and return zero rows that read exactly like an honest "your corpus has none".
+    parsed_dates: dict[str, datetime.date] = {}
     for flag, value in (("--since", args.since), ("--until", args.until)):
-        if value and not VALID_DATE.match(value):
+        if not value:
+            continue
+        if not VALID_DATE.match(value):
             parser.error(f"invalid {flag} {value!r}: expected YYYY-MM-DD")
-    if args.unknown == "only" and (args.server_version or args.fingerprint):
-        # An unattributed record has no version/fingerprint to compare, so it can
-        # never equal a specific observed value. --unknown only combined with
-        # --server-version or --fingerprint is vacuous by construction: the result
-        # is always empty, regardless of corpus. Reject rather than silently
-        # report zero results, which reads as "your corpus has none".
+        try:
+            parsed_dates[flag] = datetime.date.fromisoformat(value)
+        except ValueError:
+            parser.error(f"invalid {flag} {value!r}: not a real calendar date")
+    if parsed_dates.get("--since", datetime.date.min) > parsed_dates.get(
+        "--until", datetime.date.max
+    ):
         parser.error(
-            "--unknown only combined with --server-version/--fingerprint always "
-            "yields zero results: an unattributed record can never match a "
-            "specific observed value. Drop --unknown only, or drop the version/"
-            "fingerprint filter."
+            f"--since {args.since} is after --until {args.until}: an inverted window "
+            "always yields zero results. Swap them."
+        )
+
+    # --unknown is defined against the ACTIVE dimension (Filters.selects and Coverage both
+    # ask "does this call carry a value for group_by?"), so only a filter on THAT dimension
+    # is vacuous with `only`. The other dimension's filter is a legitimate, non-empty query:
+    #   --group-by version --unknown only --fingerprint fp-1
+    #     → "calls from fingerprint fp-1 that stamp no version" — exactly the corpus today.
+    # Rejecting it too, as this check first did, refused a question the report can answer.
+    identity_filter = (
+        args.server_version if args.group_by == "version" else args.fingerprint
+    )
+    if args.unknown == "only" and identity_filter:
+        parser.error(
+            f"--unknown only combined with a {args.group_by} filter always yields zero "
+            f"results: an unattributed record can never match a specific {args.group_by}. "
+            f"Drop --unknown only, or drop the {args.group_by} filter."
         )
     return args
 

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -1,5 +1,6 @@
 """Tests for mcp_error_audit.py, run via: uvx pytest plugins/mcp-error-audit/tests/ -q"""
 
+import collections
 import json
 import os
 import sys
@@ -442,3 +443,82 @@ def test_tool_use_without_id_is_counted_as_no_result(tmp_path):
     result = mea.audit(root, "srv", 3)
     srv_stat = result["servers"]["srv"]
     assert srv_stat.calls == 1  # Must be counted in discovery mode
+
+
+# --- scope-aware recovery ---------------------------------------------------
+
+
+def _versioned_error(code, version):
+    return json.dumps(
+        {"ok": False, "error": {"code": code, "message": "boom", "retryable": False},
+         "meta": {"server_version": version}}
+    )
+
+
+def _versioned_ok(version):
+    return json.dumps({"ok": True, "meta": {"server_version": version}})
+
+
+def test_recovery_requires_the_same_version(tmp_path):
+    """An error on v1 followed by a success on v2 is NOT recovery for v1.
+
+    The environment changed underneath; the honest answer is indeterminate.
+    """
+    root = str(tmp_path)
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            tool_result("t1", _versioned_error("boom_code", "1.0.0"), "2026-07-01T00:00:01Z", True),
+            tool_use("t2", "mcp__srv__go", {}, "2026-07-01T00:01:00Z"),
+            tool_result("t2", _versioned_ok("2.0.0"), "2026-07-01T00:01:01Z"),
+        ],
+    )
+    result = mea.audit(root, "srv", 3)
+    stat = result["codes"]["boom_code"]
+    assert stat.recovered == 0
+    assert stat.cross_version_success == 1
+
+
+def test_recovery_counts_within_the_same_version(tmp_path):
+    root = str(tmp_path)
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            tool_result("t1", _versioned_error("boom_code", "1.0.0"), "2026-07-01T00:00:01Z", True),
+            tool_use("t2", "mcp__srv__go", {}, "2026-07-01T00:01:00Z"),
+            tool_result("t2", _versioned_ok("1.0.0"), "2026-07-01T00:01:01Z"),
+        ],
+    )
+    stat = mea.audit(root, "srv", 3)["codes"]["boom_code"]
+    assert stat.recovered == 1
+    assert stat.cross_version_success == 0
+
+
+def test_multi_version_folded_session_attributes_each_call(tmp_path):
+    """A session can span an upgrade: the parent transcript and its subagent sidechain
+    fold into ONE session, but each call keeps its own version."""
+    root = str(tmp_path)
+    write_jsonl(
+        os.path.join(root, "proj", "abc.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            tool_result("t1", _versioned_error("boom_code", "1.0.0"), "2026-07-01T00:00:01Z", True),
+        ],
+    )
+    write_jsonl(
+        os.path.join(root, "proj", "abc", "subagents", "agent-1.jsonl"),
+        [
+            tool_use("t2", "mcp__srv__go", {}, "2026-07-02T00:00:00Z"),
+            tool_result("t2", _versioned_error("boom_code", "2.0.0"), "2026-07-02T00:00:01Z", True),
+        ],
+    )
+    result = mea.audit(root, "srv", 3)
+    stat = result["codes"]["boom_code"]
+    assert stat.by_scope == collections.Counter({"1.0.0": 1, "2.0.0": 1})
+    # one folded session, but two scopes within it — session counts must not imply
+    # a single version
+    assert len(result["audit_sessions"]) == 1
+    assert stat.session_count() == 1
+    assert stat.sessions == {("1.0.0", "proj/abc"), ("2.0.0", "proj/abc")}

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -721,6 +721,81 @@ def test_rate_uses_attributed_calls_and_flags_partial(tmp_path):
     assert "partial" in text.lower()
 
 
+def _mixed_attribution_corpus(root):
+    """1.0.0: 2 calls, 1 error (50%). No envelope: 3 calls, 1 error (33.3%).
+
+    Overall: 2 errors / 5 calls = 40.0% — a figure that belongs to NO release.
+    """
+    records = [
+        tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+        tool_result("t1", _versioned_error("known", "1.0.0"), "2026-07-01T00:00:01Z", True),
+        tool_use("t2", "mcp__srv__go", {}, "2026-07-01T00:01:00Z"),
+        tool_result("t2", _versioned_ok("1.0.0"), "2026-07-01T00:01:01Z"),
+        tool_use("t3", "mcp__srv__go", {}, "2026-07-01T00:02:00Z"),
+        tool_result("t3", "Connection closed", "2026-07-01T00:02:01Z", True),
+        tool_use("t4", "mcp__srv__go", {}, "2026-07-01T00:03:00Z"),
+        tool_result("t4", "plain text, no envelope", "2026-07-01T00:03:01Z"),
+        tool_use("t5", "mcp__srv__go", {}, "2026-07-01T00:04:00Z"),
+        tool_result("t5", "plain text, no envelope", "2026-07-01T00:04:01Z"),
+    ]
+    write_jsonl(os.path.join(root, "proj", "s1.jsonl"), records)
+
+
+def test_header_rate_is_labeled_as_spanning_all_calls(tmp_path):
+    """The ONE rate printed was errors/ALL calls, under a note claiming the opposite.
+
+    The header rate (2/5 = 40.0%) includes unattributed calls. It is fine to print —
+    but only labeled as what it is. It must NOT sit under a note asserting that "rates
+    below are computed over attributed calls only", because that describes a
+    computation the report never performed.
+    """
+    root = str(tmp_path)
+    _mixed_attribution_corpus(root)
+    text = mea.to_text(mea.audit(root, "srv", 3))
+    header = next(ln for ln in text.splitlines() if ln.startswith("scanned "))
+    assert "2 errors (40.0% of all matched calls, attributed or not)" in header
+    # The old note claimed the rates were attributed-only. They were not, and there
+    # were no per-scope rates at all. That exact sentence must be gone.
+    assert "computed over attributed calls only" not in text
+
+
+def test_per_scope_rates_use_that_scopes_own_denominator(tmp_path):
+    """Every per-scope rate divides by THAT scope's calls — never the global count."""
+    root = str(tmp_path)
+    _mixed_attribution_corpus(root)
+    result = mea.audit(root, "srv", 3)
+    text = mea.to_text(result)
+    lines = text.splitlines()
+    header_idx = lines.index("## Errors by code × version")
+
+    calls_row = next(ln for ln in lines[header_idx + 1 :] if ln.startswith("calls"))
+    rate_row = next(ln for ln in lines[header_idx + 1 :] if ln.startswith("err%"))
+    assert calls_row.split() == ["calls", "2", "3"]
+    # 1/2 at 1.0.0 and 1/3 unattributed. Neither is the global 40.0%.
+    assert rate_row.split() == ["err%", "50.0%", "33.3%"]
+
+    assert mea.scope_rate(result, "1.0.0") == "50.0%"
+    data = json.loads(mea.to_json(result))
+    assert data["coverage"]["calls_by_scope"] == {"1.0.0": 2, "unknown": 3}
+    assert data["coverage"]["errors_by_scope"] == {"1.0.0": 1, "unknown": 1}
+
+
+def test_partial_note_describes_what_the_report_actually_does(tmp_path):
+    """The PARTIAL note must describe the report's real computation, not a fiction."""
+    root = str(tmp_path)
+    _mixed_attribution_corpus(root)
+    text = mea.to_text(mea.audit(root, "srv", 3))
+    note = next(ln for ln in text.splitlines() if ln.startswith("NOTE: PARTIAL"))
+    assert "3 calls could not be attributed to a version" in note
+    # It must point at the real mechanism: per-column denominators, unknown isolated.
+    assert "own denominator" in note and "unknown" in note
+
+    # And when EVERY call is attributed, there is nothing partial to warn about.
+    clean = str(tmp_path / "clean")
+    _clean_release_corpus(clean)
+    assert "PARTIAL" not in mea.to_text(mea.audit(clean, "srv", 3))
+
+
 def test_matrix_shows_code_by_version(tmp_path):
     root = str(tmp_path)
     _two_version_corpus(root)

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -822,10 +822,35 @@ def test_args_string_bare_server_and_empty():
 
 
 def test_args_string_rejects_quotes():
-    """The command substitutes $ARGUMENTS inside single quotes; a quote in the input
-    would break out of them. Refuse rather than risk a shell escape."""
+    """Defense-in-depth at the PYTHON layer only: a stray quote in --args would
+    otherwise produce a confusing shlex parse. This does NOT and cannot prevent shell
+    injection — bash tokenizes $ARGUMENTS before python ever runs; the allowed-tools
+    allowlist in commands/mcp-error-audit.md is what guards that layer."""
     with pytest.raises(SystemExit):
         mea.parse_argv(["--args", "codex --since '2026-07-12'"])
+
+
+def test_args_string_trailing_backslash_is_a_clean_error():
+    """A trailing backslash with no quotes passes the quote check but makes
+    shlex.split raise ValueError('No escaped character'). That must surface as a
+    clean parser.error (SystemExit, exit code 2), not an uncaught traceback."""
+    with pytest.raises(SystemExit) as exc_info:
+        mea.parse_argv(["--args", "codex --since 2026-07-12\\"])
+    assert exc_info.value.code == 2
+
+
+def test_unknown_only_with_server_version_is_rejected():
+    """--unknown only paired with --server-version is vacuous by construction: an
+    unattributed record can never equal a specific observed version, so the result
+    is always empty regardless of corpus. Reject it at validation time instead of
+    silently reporting zero results."""
+    with pytest.raises(SystemExit):
+        mea.parse_argv(["--args", "codex --unknown only --server-version 0.10.0"])
+
+
+def test_unknown_only_with_fingerprint_is_rejected():
+    with pytest.raises(SystemExit):
+        mea.parse_argv(["--args", "codex --unknown only --fingerprint srv/0.1/schema-38"])
 
 
 def test_fingerprint_validation_allows_slashes_server_does_not():

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -673,11 +673,29 @@ def test_rate_uses_attributed_calls_and_flags_partial(tmp_path):
 def test_matrix_shows_code_by_version(tmp_path):
     root = str(tmp_path)
     _two_version_corpus(root)
-    data = json.loads(mea.to_json(mea.audit(root, "srv", 3)))
+    result = mea.audit(root, "srv", 3)
+    data = json.loads(mea.to_json(result))
     assert data["by_code"]["old_code"]["by_scope"] == {"1.0.0": 1}
     assert data["by_code"]["new_code"]["by_scope"] == {"2.0.0": 1}
-    text = mea.to_text(mea.audit(root, "srv", 3))
-    assert "1.0.0" in text and "2.0.0" in text
+
+    text = mea.to_text(result)
+    # Structure unique to the matrix: its section header must be present.
+    assert "## Errors by code × version" in text
+    lines = text.splitlines()
+    header_idx = lines.index("## Errors by code × version")
+    header_row = lines[header_idx + 1]
+    # Header row carries exactly the two scope labels, in order (tokenized by
+    # whitespace: if columns ran together, this would collapse to one merged
+    # token instead of two).
+    assert header_row.split() == ["code", "1.0.0", "2.0.0"]
+
+    old_code_row = next(ln for ln in lines[header_idx + 2 :] if ln.startswith("old_code"))
+    # old_code was only observed at 1.0.0 — its 2.0.0 column must show the
+    # NOT-OBSERVED zero, not be missing or blank.
+    assert old_code_row.split() == ["old_code", "1", "0"]
+
+    new_code_row = next(ln for ln in lines[header_idx + 2 :] if ln.startswith("new_code"))
+    assert new_code_row.split() == ["new_code", "0", "1"]
 
 
 def test_text_report_says_not_observed_never_fixed(tmp_path):
@@ -685,6 +703,53 @@ def test_text_report_says_not_observed_never_fixed(tmp_path):
     _two_version_corpus(root)
     text = mea.to_text(mea.audit(root, "srv", 3, mea.Filters(server_version="2.0.0")))
     assert "fixed" not in text.lower()
+    # The NOT-OBSERVED caveat itself must be present, not merely absent of "fixed".
+    assert "NOT OBSERVED" in text
+    assert "not a fix" in text
+
+
+def test_matrix_aligns_columns_for_long_fingerprint_labels(tmp_path):
+    """Finding: at fixed width-14 columns, a fingerprint label like
+    'codex-in-claude/0.1/schema-38' (30 chars) overruns its column and runs
+    into the next header/value, breaking alignment. The matrix must size
+    columns to their content instead.
+    """
+    root = str(tmp_path)
+    fp1 = "codex-in-claude/0.1/schema-38"
+    fp2 = "codex-in-claude/2.0/schema-99"
+
+    def fp_error(code, fp):
+        return json.dumps(
+            {
+                "ok": False,
+                "error": {"code": code, "message": "boom", "retryable": False},
+                "meta": {"fingerprint": fp},
+            }
+        )
+
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            tool_result("t1", fp_error("old_code", fp1), "2026-07-01T00:00:01Z", True),
+            tool_use("t2", "mcp__srv__go", {}, "2026-07-02T00:00:00Z"),
+            tool_result("t2", fp_error("old_code", fp2), "2026-07-02T00:00:01Z", True),
+        ],
+    )
+    result = mea.audit(root, "srv", 3, mea.Filters(group_by="fingerprint"))
+    text = mea.to_text(result)
+
+    assert "## Errors by code × fingerprint" in text
+    lines = text.splitlines()
+    header_idx = lines.index("## Errors by code × fingerprint")
+    header_row = lines[header_idx + 1]
+    data_row = next(ln for ln in lines[header_idx + 2 :] if ln.startswith("old_code"))
+
+    # If the columns ran together (the bug), the two fingerprint labels would
+    # merge into a single whitespace token instead of tokenizing separately —
+    # same for the data row's counts.
+    assert header_row.split() == ["code", fp1, fp2]
+    assert data_row.split() == ["old_code", "1", "1"]
 
 
 def test_discovery_output_is_unchanged_by_version_work(tmp_path):

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -1277,17 +1277,88 @@ def test_args_string_trailing_backslash_is_a_clean_error():
 
 
 def test_unknown_only_with_server_version_is_rejected():
-    """--unknown only paired with --server-version is vacuous by construction: an
-    unattributed record can never equal a specific observed version, so the result
-    is always empty regardless of corpus. Reject it at validation time instead of
-    silently reporting zero results."""
+    """--unknown only paired with a filter on the ACTIVE dimension is vacuous by
+    construction: an unattributed record can never equal a specific observed value, so
+    the result is always empty regardless of corpus. Reject it at validation time instead
+    of silently reporting zero results."""
     with pytest.raises(SystemExit):
         mea.parse_argv(["--args", "codex --unknown only --server-version 0.10.0"])
 
 
 def test_unknown_only_with_fingerprint_is_rejected():
+    """Same vacuity, but only when fingerprint IS the active dimension."""
     with pytest.raises(SystemExit):
-        mea.parse_argv(["--args", "codex --unknown only --fingerprint srv/0.1/schema-38"])
+        mea.parse_argv(
+            ["--args", "codex --group-by fingerprint --unknown only "
+                       "--fingerprint srv/0.1/schema-38"]
+        )
+
+
+def test_unknown_only_allows_a_filter_on_the_OTHER_dimension(tmp_path):
+    """The vacuity is dimension-relative, and the rejection must be too.
+
+    `--group-by version --unknown only --fingerprint fp-1` asks "which calls from
+    fingerprint fp-1 stamp no version?" — the exact shape of the corpus that exists today,
+    where servers stamp a fingerprint and no version. It is answerable and NON-EMPTY. The
+    first version of the check rejected any identity filter and so refused the question.
+
+    Both directions are covered: the inverse (group by fingerprint, filter by version) is
+    equally legitimate.
+    """
+    args = mea.parse_argv(
+        ["--args", "codex --group-by version --unknown only --fingerprint fp-1"]
+    )
+    assert args.unknown == "only" and args.fingerprint == "fp-1"
+    mea.parse_argv(
+        ["--args", "codex --group-by fingerprint --unknown only --server-version 1.0.0"]
+    )
+
+    # NEGATIVE CONTROL: the combo the parser now admits must actually return rows —
+    # a check that only proves argparse is quiet would be worthless.
+    root = str(tmp_path)
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            tool_result(
+                "t1",
+                json.dumps({"error": {"code": "fp_code"}, "meta": {"fingerprint": "fp-1"}}),
+                "2026-07-01T00:00:01Z",
+                True,
+            ),
+            tool_use("t2", "mcp__srv__go", {}, "2026-07-02T00:00:00Z"),
+            tool_result(
+                "t2",
+                json.dumps({"error": {"code": "other"}, "meta": {"fingerprint": "fp-2"}}),
+                "2026-07-02T00:00:01Z",
+                True,
+            ),
+        ],
+    )
+    res = mea.audit(
+        root, "srv", 3,
+        mea.Filters(group_by="version", unknown="only", fingerprint="fp-1"),
+    )
+    assert res["coverage"].total_calls == 1  # fp-2's call is filtered out
+    assert set(res["codes"]) == {"fp_code"}
+    assert res["coverage"].attributed_calls == 0  # none of them stamp a version
+
+
+def test_impossible_and_inverted_dates_are_rejected():
+    """A shape check is not a date check. `2026-02-31` matches YYYY-MM-DD and does not
+    exist; an inverted window can never select anything. Both used to sail through and
+    return zero rows, which reads exactly like an honest "your corpus has none"."""
+    with pytest.raises(SystemExit):
+        mea.parse_argv(["--args", "codex --since 2026-02-31"])
+    with pytest.raises(SystemExit):
+        mea.parse_argv(["--args", "codex --until 2026-13-01"])
+    with pytest.raises(SystemExit):
+        mea.parse_argv(["--args", "codex --since 2026-12-01 --until 2026-01-01"])
+
+    # POSITIVE CONTROL: real dates, and an equal-bounds window (a single day), still pass.
+    args = mea.parse_argv(["--args", "codex --since 2026-02-28 --until 2026-02-28"])
+    assert args.since == "2026-02-28" and args.until == "2026-02-28"
+    mea.parse_argv(["--args", "codex --since 2024-02-29"])  # a real leap day
 
 
 def test_fingerprint_validation_allows_slashes_server_does_not():
@@ -1358,3 +1429,106 @@ def test_filter_excludes_everything_message_names_the_filter(tmp_path):
     assert "No MCP tool calls matched" not in text
     assert "matched 2 calls for this server, but 0 after scoping to" in text
     assert "server-version 9.9.9" in text
+
+
+def test_error_dates_come_from_the_result_not_the_call(tmp_path):
+    """first_seen/last_seen/samples are OCCURRENCE facts: they date when the error came
+    back, not when the call was issued.
+
+    The version-scoping refactor moved every call onto a single CallRecord.ts captured
+    from the `tool_use` record, and these fields silently followed it. For a call that
+    starts at 23:59 and fails at 00:01 the next day, that reports the error on the wrong
+    DAY — and `--since`/`--until` legitimately need the call's start time (filtering the
+    two records apart would split the pair), so one timestamp cannot serve both.
+
+    The corpus below is built so the two timestamps disagree on the calendar date, which
+    is the only way this test can fail loudly rather than by a few seconds.
+    """
+    root = str(tmp_path)
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T23:59:00Z"),
+            tool_result("t1", _versioned_error("boom", "1.0.0"), "2026-07-02T00:01:00Z", True),
+        ],
+    )
+    stat = mea.audit(root, "srv", 3)["codes"]["boom"]
+    assert stat.first_seen == "2026-07-02T00:01:00Z"  # result, not the 07-01 call
+    assert stat.last_seen == "2026-07-02T00:01:00Z"
+    assert [s["ts"] for s in stat.samples] == ["2026-07-02T00:01:00Z"]
+
+    # The date FILTER still reads the call's start time — the pair must not be split.
+    span = mea.audit(root, "srv", 3, mea.Filters(since="2026-07-01", until="2026-07-01"))
+    assert span["coverage"].total_calls == 1
+    assert span["coverage"].excluded_missing_timestamp == 0
+
+
+def test_matrix_stays_aligned_when_a_cell_is_wider_than_its_label(tmp_path):
+    """Column width was sized from the scope LABEL alone. A cell wider than that width
+    expands past the format spec, so that row runs longer than the header and the table
+    stops lining up. Width must follow the widest thing actually printed.
+
+    Reproduced with call counts that need more columns than the label "1.0.0" (5 chars)
+    or MIN_SCOPE_COL (6) provide.
+    """
+    cov = mea.Coverage(total_calls=2_000_000, attributed_calls=2_000_000)
+    cov.calls_by_scope.update({"1.0.0": 1_500_000, "2.0.0": 500_000})
+    stat = mea.CodeStat(count=1_234_567)
+    stat.by_scope.update({"1.0.0": 1_234_567})
+    stat.tools.update({"go": 1_234_567})
+    result = {
+        "server": "srv",
+        "matched_servers": ["srv"],
+        "files_scanned": 1,
+        "sessions_scanned": 1,
+        "servers": {"srv": mea.ServerStat(calls=2_000_000, errors=1_234_567)},
+        "audit_sessions": {"s1"},
+        "total_calls": collections.Counter({"go": 2_000_000}),
+        "total_errors": collections.Counter({"go": 1_234_567}),
+        "codes": {"boom": stat},
+        "coverage": cov,
+        "filters": mea.Filters(),
+        "raw_matched_calls": 2_000_000,
+    }
+    lines = mea.to_text(result).splitlines()
+    start = lines.index(next(ln for ln in lines if ln.startswith("code ")))
+    matrix = lines[start:start + 5]  # header, boom row, rule, calls row, err% row
+    assert len({len(ln) for ln in matrix}) == 1, (
+        "matrix rows differ in width:\n" + "\n".join(f"{len(ln):>3} |{ln}|" for ln in matrix)
+    )
+
+    # NEGATIVE CONTROL: the assertion above can fail. Sizing off the label alone (the old
+    # behavior) leaves the count cell wider than its column, which is what it must catch.
+    old_width = max(mea.MIN_SCOPE_COL, len("1.0.0"))
+    assert len(str(1_234_567)) > old_width
+
+
+def test_json_carries_the_filters_that_defined_its_population(tmp_path):
+    """Every count in the JSON is scoped by the active filters, so the filters have to
+    ship with it. `date_scoped: true` alone loses the window; a version/fingerprint/
+    unknown scope was unreconstructable from the serialized report entirely. A scoped
+    statistic whose scope is not stated is the same failure as an unnamed denominator.
+    """
+    root = str(tmp_path)
+    _two_version_corpus(root)
+    filters = mea.Filters(
+        server_version="1.0.0", since="2026-07-01", until="2026-07-05", unknown="exclude"
+    )
+    data = json.loads(mea.to_json(mea.audit(root, "srv", 3, filters)))
+    assert data["coverage"]["active_filters"] == {
+        "server_version": "1.0.0",
+        "fingerprint": None,
+        "since": "2026-07-01",
+        "until": "2026-07-05",
+        "unknown": "exclude",
+    }
+
+    # An unscoped run says so explicitly rather than omitting the key.
+    plain = json.loads(mea.to_json(mea.audit(root, "srv", 3)))
+    assert plain["coverage"]["active_filters"] == {
+        "server_version": None,
+        "fingerprint": None,
+        "since": None,
+        "until": None,
+        "unknown": "include",
+    }

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -749,6 +749,60 @@ def test_matrix_shows_code_by_version(tmp_path):
     assert new_code_row.split() == ["new_code", "0", "1"]
 
 
+def _clean_release_corpus(root):
+    """1.0.0: one error, no clean calls. 2.0.0: twenty clean calls, zero errors."""
+    records = [
+        tool_use("t0", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+        tool_result("t0", _versioned_error("old_code", "1.0.0"), "2026-07-01T00:00:01Z", True),
+    ]
+    for i in range(20):
+        records.append(tool_use(f"v{i}", "mcp__srv__go", {}, f"2026-07-10T00:{i:02d}:00Z"))
+        records.append(tool_result(f"v{i}", _versioned_ok("2.0.0"), f"2026-07-10T00:{i:02d}:01Z"))
+    write_jsonl(os.path.join(root, "proj", "s1.jsonl"), records)
+
+
+def test_calls_are_counted_by_scope_not_only_errors(tmp_path):
+    """The denominator for 'not observed in 2.0.0 over N attributed calls' must EXIST.
+
+    aggregate() counted calls only by tool, and CodeStat.by_scope counted only errors,
+    so there was no per-scope call denominator anywhere. The flagship sentence in the
+    spec was literally uncomputable.
+    """
+    root = str(tmp_path)
+    _clean_release_corpus(root)
+    cov = mea.audit(root, "srv", 3)["coverage"]
+    assert cov.calls_by_scope == collections.Counter({"1.0.0": 1, "2.0.0": 20})
+    assert cov.total_calls == 21
+    assert cov.attributed_calls == 21
+    assert cov.total_calls == cov.attributed_calls + sum(cov.unknown.values())
+
+    data = json.loads(mea.to_json(mea.audit(root, "srv", 3)))
+    assert data["coverage"]["calls_by_scope"] == {"1.0.0": 1, "2.0.0": 20}
+
+
+def test_zero_error_release_still_gets_a_matrix_column(tmp_path):
+    """A release with 20 clean calls and zero errors must APPEAR in the matrix.
+
+    Columns were derived from ERROR scopes, so the release the user is actually
+    running — clean so far — did not appear at all, and the audit said nothing about
+    the one question it exists to answer.
+    """
+    root = str(tmp_path)
+    _clean_release_corpus(root)
+    text = mea.to_text(mea.audit(root, "srv", 3))
+    lines = text.splitlines()
+    header_idx = lines.index("## Errors by code × version")
+    header_row = lines[header_idx + 1]
+    assert header_row.split() == ["code", "1.0.0", "2.0.0"]
+
+    old_row = next(ln for ln in lines[header_idx + 2 :] if ln.startswith("old_code"))
+    assert old_row.split() == ["old_code", "1", "0"]
+
+    # The per-column denominator: the N in "not observed in 2.0.0 over N calls".
+    calls_row = next(ln for ln in lines[header_idx + 2 :] if ln.startswith("calls"))
+    assert calls_row.split() == ["calls", "1", "20"]
+
+
 def test_text_report_says_not_observed_never_fixed(tmp_path):
     root = str(tmp_path)
     _two_version_corpus(root)

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -627,6 +627,72 @@ def test_date_filter_excludes_undated_calls_as_missing_timestamp(tmp_path):
     assert set(result["codes"]) == {"dated_error"}
 
 
+def _fingerprint_only_corpus(root):
+    """The real corpus today: every call carries a fingerprint, none carries a version."""
+    fp_err = json.dumps(
+        {"ok": False, "error": {"code": "fp_code", "message": "b", "retryable": False},
+         "meta": {"fingerprint": "srv/0.1/schema-38"}}
+    )
+    fp_ok = json.dumps({"ok": True, "meta": {"fingerprint": "srv/0.1/schema-38"}})
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            tool_result("t1", fp_err, "2026-07-01T00:00:01Z", True),
+            tool_use("t2", "mcp__srv__go", {}, "2026-07-01T00:01:00Z"),
+            tool_result("t2", fp_ok, "2026-07-01T00:01:01Z"),
+        ],
+    )
+
+
+def test_unknown_filter_is_dimension_aware(tmp_path):
+    """`--unknown` must judge unknown-ness on the ACTIVE dimension, exactly as Coverage does.
+
+    Filters.selects() tested rec.unknown_reason ("was there any envelope?") while Coverage
+    tested scope != UNKNOWN ("does this call carry a value for the dimension I am grouping
+    by?"). On a fingerprint-only corpus — which is the real corpus today, since no server
+    stamps a version yet — the two definitions diverge completely:
+
+      --group-by version --unknown exclude  was a silent NO-OP (nothing has an unknown_reason)
+      --group-by version --unknown only     returned ZERO calls, while coverage in the same
+                                            run reported those very calls as unattributed.
+
+    The spec says `only` exists to make the unknown bucket inspectable rather than a silent
+    drain. One definition, dimension-aware, everywhere.
+    """
+    root = str(tmp_path)
+    _fingerprint_only_corpus(root)
+
+    # Grouping by VERSION: nothing carries a version, so every call is unknown.
+    v_only = mea.audit(root, "srv", 3, mea.Filters(group_by="version", unknown="only"))
+    assert v_only["coverage"].total_calls == 2
+    assert set(v_only["codes"]) == {"fp_code"}  # the unknown bucket is inspectable
+    assert v_only["coverage"].attributed_calls == 0
+
+    v_excl = mea.audit(root, "srv", 3, mea.Filters(group_by="version", unknown="exclude"))
+    assert v_excl["coverage"].total_calls == 0  # was 2: a silent no-op
+    assert set(v_excl["codes"]) == set()
+
+    # Grouping by FINGERPRINT: every call carries one, so the buckets invert.
+    f_only = mea.audit(root, "srv", 3, mea.Filters(group_by="fingerprint", unknown="only"))
+    assert f_only["coverage"].total_calls == 0
+    f_excl = mea.audit(root, "srv", 3, mea.Filters(group_by="fingerprint", unknown="exclude"))
+    assert f_excl["coverage"].total_calls == 2
+    assert f_excl["coverage"].attributed_calls == 2
+
+    # The invariant holds on every one of these paths.
+    for res in (v_only, v_excl, f_only, f_excl):
+        cov = res["coverage"]
+        assert cov.total_calls == cov.attributed_calls + sum(cov.unknown.values())
+
+    # POSITIVE CONTROL: `exclude` under group_by=version is not vacuously empty because
+    # the filter is broken — the same flag surfaces calls when a version IS present.
+    _two_version_corpus(str(tmp_path / "versioned"))
+    ok = mea.audit(str(tmp_path / "versioned"), "srv", 3,
+                   mea.Filters(group_by="version", unknown="exclude"))
+    assert ok["coverage"].total_calls == 2
+
+
 def test_unknown_only_and_exclude(tmp_path):
     root = str(tmp_path)
     write_jsonl(

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -325,3 +325,88 @@ def test_extract_rejects_non_string_and_empty():
     assert mea.extract_version({"server_version": ""}) is None
     assert mea.extract_version({"server_version": 10}) is None
     assert mea.extract_version({"meta": "not-a-dict"}) is None
+
+
+# --- call records -----------------------------------------------------------
+
+
+def test_records_attribute_version_and_fingerprint(tmp_path):
+    root = str(tmp_path)
+    body = json.dumps(
+        {"ok": True, "meta": {"server_version": "0.10.0", "fingerprint": "srv/0.1/schema-38"}}
+    )
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {"a": 1}, "2026-07-01T00:00:00Z"),
+            tool_result("t1", body, "2026-07-01T00:00:01Z"),
+        ],
+    )
+    recs = mea.records_for_file(os.path.join(root, "proj", "s1.jsonl"), root)
+    assert len(recs) == 1
+    assert recs[0].tool == "go"
+    assert recs[0].version == "0.10.0"
+    assert recs[0].fingerprint == "srv/0.1/schema-38"
+    assert recs[0].unknown_reason is None
+    assert recs[0].is_error is False
+
+
+def test_records_unknown_reasons(tmp_path):
+    root = str(tmp_path)
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            # no paired result at all (aborted / interrupted)
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            # a result with no JSON envelope
+            tool_use("t2", "mcp__srv__go", {}, "2026-07-01T00:01:00Z"),
+            tool_result("t2", "MCP error -32000: Connection closed", "2026-07-01T00:01:01Z", True),
+            # a well-formed envelope that carries no version
+            tool_use("t3", "mcp__srv__go", {}, "2026-07-01T00:02:00Z"),
+            tool_result("t3", json.dumps({"ok": True, "data": 1}), "2026-07-01T00:02:01Z"),
+        ],
+    )
+    recs = {r.input_id: r for r in mea.records_for_file(os.path.join(root, "proj", "s1.jsonl"), root)}
+    assert recs["t1"].unknown_reason == "no_result"
+    assert recs["t2"].unknown_reason == "unparseable_result"
+    assert recs["t3"].unknown_reason == "not_emitted"
+    assert all(r.version is None for r in recs.values())
+
+
+def test_unparseable_error_is_still_an_error(tmp_path):
+    """Attribution and classification are orthogonal.
+
+    A transport drop carries no envelope, so its release is unknown — but it is still a
+    REAL error and must stay in the error totals. Sweeping it into an 'unknown' bucket
+    that reads as 'not an error' would erase genuine transport failures.
+    """
+    root = str(tmp_path)
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            tool_result("t1", "MCP error -32000: Connection closed", "2026-07-01T00:00:01Z", True),
+        ],
+    )
+    (rec,) = mea.records_for_file(os.path.join(root, "proj", "s1.jsonl"), root)
+    assert rec.is_error is True
+    assert rec.code == "transport_connection_closed"
+    assert rec.version is None
+    assert rec.unknown_reason == "unparseable_result"
+
+
+def test_records_are_in_result_order_with_unpaired_last(tmp_path):
+    root = str(tmp_path)
+    ok = json.dumps({"ok": True, "meta": {"server_version": "1.0.0"}})
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            tool_use("t2", "mcp__srv__go", {}, "2026-07-01T00:01:00Z"),
+            tool_use("t3", "mcp__srv__go", {}, "2026-07-01T00:02:00Z"),  # never answered
+            tool_result("t2", ok, "2026-07-01T00:03:00Z"),
+            tool_result("t1", ok, "2026-07-01T00:04:00Z"),
+        ],
+    )
+    recs = mea.records_for_file(os.path.join(root, "proj", "s1.jsonl"), root)
+    assert [r.input_id for r in recs] == ["t2", "t1", "t3"]

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -522,3 +522,99 @@ def test_multi_version_folded_session_attributes_each_call(tmp_path):
     assert len(result["audit_sessions"]) == 1
     assert stat.session_count() == 1
     assert stat.sessions == {("1.0.0", "proj/abc"), ("2.0.0", "proj/abc")}
+
+
+# --- filters ----------------------------------------------------------------
+
+
+def _two_version_corpus(root):
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            tool_result("t1", _versioned_error("old_code", "1.0.0"), "2026-07-01T00:00:01Z", True),
+            tool_use("t2", "mcp__srv__go", {}, "2026-07-10T00:00:00Z"),
+            tool_result("t2", _versioned_error("new_code", "2.0.0"), "2026-07-10T00:00:01Z", True),
+        ],
+    )
+
+
+def test_filter_by_server_version(tmp_path):
+    root = str(tmp_path)
+    _two_version_corpus(root)
+    result = mea.audit(root, "srv", 3, mea.Filters(server_version="2.0.0"))
+    assert set(result["codes"]) == {"new_code"}
+    # POSITIVE CONTROL: the same filter must be able to surface the other version.
+    # A filter that matches nothing and a filter that is broken look identical.
+    other = mea.audit(root, "srv", 3, mea.Filters(server_version="1.0.0"))
+    assert set(other["codes"]) == {"old_code"}
+
+
+def test_filter_by_fingerprint(tmp_path):
+    root = str(tmp_path)
+    body = json.dumps(
+        {"ok": False, "error": {"code": "fp_code", "message": "b", "retryable": False},
+         "meta": {"fingerprint": "srv/0.1/schema-38"}}
+    )
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            tool_result("t1", body, "2026-07-01T00:00:01Z", True),
+        ],
+    )
+    hit = mea.audit(root, "srv", 3, mea.Filters(fingerprint="srv/0.1/schema-38"))
+    assert set(hit["codes"]) == {"fp_code"}
+    miss = mea.audit(root, "srv", 3, mea.Filters(fingerprint="srv/0.1/schema-1"))
+    assert set(miss["codes"]) == set()
+
+
+def test_date_filter_uses_the_call_timestamp_not_the_result(tmp_path):
+    """A call that STARTS inside the window is counted and classified even when its
+    result lands outside it. Filtering the two records independently would drop the
+    tool_use while keeping its result (or vice versa) and manufacture phantom
+    `no_result` calls — corrupting the denominator."""
+    root = str(tmp_path)
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            # starts inside the window, answers after it
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-05T23:59:00Z"),
+            tool_result("t1", _versioned_error("inside", "1.0.0"), "2026-07-06T00:30:00Z", True),
+            # starts outside the window, answers inside it
+            tool_use("t2", "mcp__srv__go", {}, "2026-07-04T00:00:00Z"),
+            tool_result("t2", _versioned_error("outside", "1.0.0"), "2026-07-05T00:00:00Z", True),
+        ],
+    )
+    result = mea.audit(root, "srv", 3, mea.Filters(since="2026-07-05", until="2026-07-05"))
+    assert set(result["codes"]) == {"inside"}
+
+
+def test_date_filter_excludes_undated_calls_as_missing_timestamp(tmp_path):
+    root = str(tmp_path)
+    rec_use = tool_use("t1", "mcp__srv__go", {}, "2026-07-05T00:00:00Z")
+    del rec_use["timestamp"]  # an undated call cannot be placed in a window
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [rec_use, tool_result("t1", _versioned_error("c", "1.0.0"), "2026-07-05T00:00:01Z", True)],
+    )
+    result = mea.audit(root, "srv", 3, mea.Filters(since="2026-07-05"))
+    assert set(result["codes"]) == set()
+    assert result["coverage"].unknown["missing_timestamp"] == 1
+
+
+def test_unknown_only_and_exclude(tmp_path):
+    root = str(tmp_path)
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            tool_result("t1", _versioned_error("known", "1.0.0"), "2026-07-01T00:00:01Z", True),
+            tool_use("t2", "mcp__srv__go", {}, "2026-07-01T00:02:00Z"),
+            tool_result("t2", "Connection closed", "2026-07-01T00:02:01Z", True),
+        ],
+    )
+    only = mea.audit(root, "srv", 3, mea.Filters(unknown="only"))
+    assert set(only["codes"]) == {"transport_connection_closed"}
+    excl = mea.audit(root, "srv", 3, mea.Filters(unknown="exclude"))
+    assert set(excl["codes"]) == {"known"}

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -410,3 +410,35 @@ def test_records_are_in_result_order_with_unpaired_last(tmp_path):
     )
     recs = mea.records_for_file(os.path.join(root, "proj", "s1.jsonl"), root)
     assert [r.input_id for r in recs] == ["t2", "t1", "t3"]
+
+
+def test_tool_use_without_id_is_counted_as_no_result(tmp_path):
+    """A tool_use with valid MCP name but no id must be counted, not dropped.
+
+    This is a regression test for the fix: previously dropped calls are now counted
+    toward discovery-mode stats, recorded with unknown_reason='no_result'.
+    """
+    root = str(tmp_path)
+    # Construct a tool_use dict without the "id" key
+    tool_use_no_id = {
+        "timestamp": "2026-07-01T00:00:00Z",
+        "message": {
+            "content": [{"type": "tool_use", "name": "mcp__srv__do_thing", "input": {}}]
+        },
+    }
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [tool_use_no_id],
+    )
+
+    # Test 1: records_for_file returns a record with unknown_reason='no_result'
+    recs = mea.records_for_file(os.path.join(root, "proj", "s1.jsonl"), root)
+    assert len(recs) == 1
+    assert recs[0].server == "srv"
+    assert recs[0].tool == "do_thing"
+    assert recs[0].unknown_reason == "no_result"
+
+    # Test 2: discovery mode counts it in servers[srv].calls
+    result = mea.audit(root, "srv", 3)
+    srv_stat = result["servers"]["srv"]
+    assert srv_stat.calls == 1  # Must be counted in discovery mode

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -1111,10 +1111,15 @@ def test_args_string_bare_server_and_empty():
 
 
 def test_args_string_rejects_quotes():
-    """Defense-in-depth at the PYTHON layer only: a stray quote in --args would
-    otherwise produce a confusing shlex parse. This does NOT and cannot prevent shell
-    injection — bash tokenizes $ARGUMENTS before python ever runs; the allowed-tools
-    allowlist in commands/mcp-error-audit.md is what guards that layer."""
+    """A stray quote in --args would otherwise produce a confusing shlex parse.
+
+    This is NOT a security control. It does not prevent shell injection and cannot:
+    bash tokenizes the interpolated $ARGUMENTS in commands/mcp-error-audit.md before
+    python starts, so a payload like `x' ; echo pwned #` reaches python as argv
+    ['--args', 'x'] — no quote ever arrives at this check. `allowed-tools` does not
+    guard it either: it is a PREFIX match, which the injected string still satisfies.
+    The risk predates this branch and is knowingly accepted; see parse_argv().
+    """
     with pytest.raises(SystemExit):
         mea.parse_argv(["--args", "codex --since '2026-07-12'"])
 

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -5,6 +5,8 @@ import json
 import os
 import sys
 
+import pytest
+
 sys.path.insert(
     0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "scripts")
 )
@@ -750,6 +752,43 @@ def test_matrix_aligns_columns_for_long_fingerprint_labels(tmp_path):
     # same for the data row's counts.
     assert header_row.split() == ["code", fp1, fp2]
     assert data_row.split() == ["old_code", "1", "1"]
+
+
+
+# --- CLI / slash-command argument passing -----------------------------------
+
+
+def test_args_string_round_trips_flags():
+    """The slash command hands the script ONE raw string. It must reach the parser as
+    flags — this is the test that catches the '--server' interpolation blocker."""
+    args = mea.parse_argv(["--args", "codex --server-version 0.10.0 --group-by version"])
+    assert args.server == "codex"
+    assert args.server_version == "0.10.0"
+    assert args.group_by == "version"
+
+
+def test_args_string_bare_server_and_empty():
+    assert mea.parse_argv(["--args", "codex"]).server == "codex"
+    assert mea.parse_argv(["--args", ""]).server == ""  # discovery mode
+
+
+def test_args_string_rejects_quotes():
+    """The command substitutes $ARGUMENTS inside single quotes; a quote in the input
+    would break out of them. Refuse rather than risk a shell escape."""
+    with pytest.raises(SystemExit):
+        mea.parse_argv(["--args", "codex --since '2026-07-12'"])
+
+
+def test_fingerprint_validation_allows_slashes_server_does_not():
+    args = mea.parse_argv(["--args", "codex --fingerprint codex-in-claude/0.1/schema-38"])
+    assert args.fingerprint == "codex-in-claude/0.1/schema-38"
+    with pytest.raises(SystemExit):
+        mea.parse_argv(["--args", "codex/evil"])  # server token stays strict
+
+
+def test_date_validation_rejects_non_iso():
+    with pytest.raises(SystemExit):
+        mea.parse_argv(["--args", "codex --since july"])
 
 
 def test_discovery_output_is_unchanged_by_version_work(tmp_path):

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -640,3 +640,60 @@ def test_unknown_only_and_exclude(tmp_path):
     assert set(only["codes"]) == {"transport_connection_closed"}
     excl = mea.audit(root, "srv", 3, mea.Filters(unknown="exclude"))
     assert set(excl["codes"]) == {"known"}
+
+
+# --- coverage and the matrix ------------------------------------------------
+
+
+def test_rate_uses_attributed_calls_and_flags_partial(tmp_path):
+    root = str(tmp_path)
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            tool_result("t1", _versioned_error("known", "1.0.0"), "2026-07-01T00:00:01Z", True),
+            tool_use("t2", "mcp__srv__go", {}, "2026-07-01T00:01:00Z"),
+            tool_result("t2", "Connection closed", "2026-07-01T00:01:01Z", True),
+        ],
+    )
+    result = mea.audit(root, "srv", 3)
+    cov = result["coverage"]
+    assert cov.total_calls == 2
+    assert cov.attributed_calls == 1
+    assert cov.unknown["unparseable_result"] == 1
+    assert cov.partial() is True
+
+    data = json.loads(mea.to_json(result))
+    assert data["coverage"]["attributed_calls"] == 1
+    assert data["coverage"]["partial"] is True
+    text = mea.to_text(result)
+    assert "partial" in text.lower()
+
+
+def test_matrix_shows_code_by_version(tmp_path):
+    root = str(tmp_path)
+    _two_version_corpus(root)
+    data = json.loads(mea.to_json(mea.audit(root, "srv", 3)))
+    assert data["by_code"]["old_code"]["by_scope"] == {"1.0.0": 1}
+    assert data["by_code"]["new_code"]["by_scope"] == {"2.0.0": 1}
+    text = mea.to_text(mea.audit(root, "srv", 3))
+    assert "1.0.0" in text and "2.0.0" in text
+
+
+def test_text_report_says_not_observed_never_fixed(tmp_path):
+    root = str(tmp_path)
+    _two_version_corpus(root)
+    text = mea.to_text(mea.audit(root, "srv", 3, mea.Filters(server_version="2.0.0")))
+    assert "fixed" not in text.lower()
+
+
+def test_discovery_output_is_unchanged_by_version_work(tmp_path):
+    """Golden guard: discovery keeps its all-call denominator and stays unversioned."""
+    root = str(tmp_path)
+    _two_version_corpus(root)
+    data = json.loads(mea.to_json(mea.audit(root, "", 3)))
+    assert data["mode"] == "discovery"
+    assert data["servers"]["srv"]["calls"] == 2
+    assert data["servers"]["srv"]["errors"] == 2
+    assert data["servers"]["srv"]["error_rate"] == 1.0
+    assert "coverage" not in data

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -1065,12 +1065,31 @@ def test_matrix_aligns_columns_for_long_fingerprint_labels(tmp_path):
     header_idx = lines.index("## Errors by code × fingerprint")
     header_row = lines[header_idx + 1]
     data_row = next(ln for ln in lines[header_idx + 2 :] if ln.startswith("old_code"))
+    calls_row = next(ln for ln in lines[header_idx + 2 :] if ln.startswith("calls"))
 
-    # If the columns ran together (the bug), the two fingerprint labels would
-    # merge into a single whitespace token instead of tokenizing separately —
-    # same for the data row's counts.
     assert header_row.split() == ["code", fp1, fp2]
     assert data_row.split() == ["old_code", "1", "1"]
+
+    # The assertions above are NOT enough on their own: .split() is invariant to column
+    # width, because there is always at least one space separating the fields. They pass
+    # unchanged with `col_width = 14` reintroduced. Alignment is a property of the
+    # RENDERED WIDTH, so pin that: every row of the matrix must be exactly as wide as
+    # every other, which is true iff each column is sized to its widest label.
+    # Under the bug the 29-char labels overrun their 14-char cells and the header row
+    # renders 94 chars against a 64-char data row.
+    widths = {len(header_row), len(data_row), len(calls_row)}
+    assert widths == {len(header_row)}, (
+        f"matrix rows are ragged — columns are not sized to their labels: "
+        f"header={len(header_row)} data={len(data_row)} calls={len(calls_row)}"
+    )
+    # And the columns land where the labels do: each count's right edge sits under the
+    # right edge of its own header label.
+    for i, fp in enumerate((fp1, fp2)):
+        col_end = header_row.index(fp) + len(fp)
+        assert data_row[:col_end].rstrip().endswith("1")
+        assert len(data_row[:col_end].rstrip()) == col_end, (
+            f"column {i} ({fp}) count is not right-aligned under its header label"
+        )
 
 
 

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -667,7 +667,18 @@ def test_date_filter_uses_the_call_timestamp_not_the_result(tmp_path):
     assert set(result["codes"]) == {"inside"}
 
 
-def test_date_filter_excludes_undated_calls_as_missing_timestamp(tmp_path):
+def test_date_filter_excludes_undated_calls_without_filing_it_as_unattributed(tmp_path):
+    """An undated call under a date filter is SCOPE-EXCLUDED, not attribution-failed.
+
+    It may carry a perfectly good version (as this one does: `undated_error` is
+    `_versioned_error(..., "1.0.0")`) — it is simply outside what a date filter can
+    place in a window. Filing it under coverage.unknown["missing_timestamp"] claimed
+    attribution failed when it plainly didn't, and made a fully-attributed corpus
+    print a false PARTIAL note. It must be excluded from every coverage count, exactly
+    like every other filter exclusion (version/fingerprint mismatch, --unknown
+    exclude/only) — none of which touch coverage either — and reported separately so
+    it doesn't vanish silently.
+    """
     root = str(tmp_path)
     # Build a corpus with both dated and undated calls inside the window
     records = [
@@ -678,7 +689,7 @@ def test_date_filter_excludes_undated_calls_as_missing_timestamp(tmp_path):
         tool_use("t2", "mcp__srv__go", {}, "2026-07-05T10:00:00Z"),
         tool_result("t2", _versioned_ok("1.0.0"), "2026-07-05T10:00:01Z"),
     ]
-    # undated call cannot be placed in a window
+    # undated call cannot be placed in a window — but it DOES carry a version
     rec_use = tool_use("t3", "mcp__srv__go", {}, "2026-07-05T12:00:00Z")
     del rec_use["timestamp"]
     records.extend([rec_use, tool_result("t3", _versioned_error("undated_error", "1.0.0"), "2026-07-05T12:00:01Z", True)])
@@ -691,15 +702,22 @@ def test_date_filter_excludes_undated_calls_as_missing_timestamp(tmp_path):
     assert cov.total_calls == cov.attributed_calls + sum(cov.unknown.values()), \
         f"Invariant broken: {cov.total_calls} != {cov.attributed_calls} + {sum(cov.unknown.values())}"
 
-    # Verify the undated call is excluded but still counted in total_calls
-    assert cov.unknown["missing_timestamp"] == 1
-    assert cov.total_calls == 3  # 2 dated + 1 undated
+    # The undated call is excluded from coverage entirely — not counted as unattributed.
+    assert cov.unknown["missing_timestamp"] == 0
+    assert cov.total_calls == 2  # only the two dated calls
+    assert cov.attributed_calls == 2  # both dated calls have versions; nothing is unattributed
+    assert cov.partial() is False  # a fully-attributed corpus must not read as PARTIAL
 
-    # Verify the dated calls are still counted and attributed
-    assert cov.attributed_calls == 2  # only dated calls have versions
+    # It is tracked separately, so it doesn't vanish silently.
+    assert cov.excluded_missing_timestamp == 1
 
     # Verify the error from the dated call is in the codes (undated error is excluded)
     assert set(result["codes"]) == {"dated_error"}
+
+    # The text report must say so, outside of any PARTIAL note (there is none here).
+    text = mea.to_text(result)
+    assert "PARTIAL" not in text
+    assert "1 calls with no timestamp" in text
 
 
 def _fingerprint_only_corpus(root):
@@ -900,6 +918,63 @@ def test_header_rate_is_labeled_as_spanning_all_calls(tmp_path):
     assert "computed over attributed calls only" not in text
 
 
+def test_header_rate_label_matches_denominator_under_server_version_scope(tmp_path):
+    """Regression for F1: `--server-version` narrows `calls` to just that version's
+    calls — every one of them attributed by construction — but the header kept the
+    unscoped label "all matched calls, attributed or not" regardless. The label must
+    name the set `calls` actually is.
+    """
+    root = str(tmp_path)
+    _two_version_corpus(root)  # 1.0.0: 1 call/1 error. 2.0.0: 1 call/1 error.
+    text = mea.to_text(mea.audit(root, "srv", 3, mea.Filters(server_version="1.0.0")))
+    header = next(ln for ln in text.splitlines() if ln.startswith("scanned "))
+    assert "1 calls · 1 errors (100.0% of calls scoped to server-version 1.0.0)" in header
+    # It must NOT claim to span every matched call — only 1.0.0's.
+    assert "all matched calls" not in header
+
+
+def test_header_rate_label_matches_denominator_under_unknown_exclude(tmp_path):
+    """`--unknown exclude` narrows `calls` to attributed-only — the exact inverse of
+    the old unscoped label ("attributed or not"). The label must say so.
+    """
+    root = str(tmp_path)
+    _mixed_attribution_corpus(root)  # 1.0.0: 2 calls/1 error. unattributed: 3 calls/1 error.
+    text = mea.to_text(mea.audit(root, "srv", 3, mea.Filters(unknown="exclude")))
+    header = next(ln for ln in text.splitlines() if ln.startswith("scanned "))
+    assert "2 calls · 1 errors (50.0% of calls scoped to unknown=exclude)" in header
+    assert "all matched calls" not in header
+
+
+def test_header_rate_label_matches_denominator_under_unknown_only(tmp_path):
+    """`--unknown only` narrows `calls` to entirely UNATTRIBUTED calls — the opposite
+    of "attributed or not" too, just from the other side.
+    """
+    root = str(tmp_path)
+    _mixed_attribution_corpus(root)
+    text = mea.to_text(mea.audit(root, "srv", 3, mea.Filters(unknown="only")))
+    header = next(ln for ln in text.splitlines() if ln.startswith("scanned "))
+    assert "3 calls · 1 errors (33.3% of calls scoped to unknown=only)" in header
+    assert "all matched calls" not in header
+
+
+def test_header_rate_label_matches_denominator_under_date_scope(tmp_path):
+    """`--since`/`--until` narrow `calls` to just the date window's calls."""
+    root = str(tmp_path)
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-05T00:00:00Z"),
+            tool_result("t1", _versioned_error("dated_error", "1.0.0"), "2026-07-05T00:00:01Z", True),
+            tool_use("t2", "mcp__srv__go", {}, "2026-07-05T10:00:00Z"),
+            tool_result("t2", _versioned_ok("1.0.0"), "2026-07-05T10:00:01Z"),
+        ],
+    )
+    text = mea.to_text(mea.audit(root, "srv", 3, mea.Filters(since="2026-07-05")))
+    header = next(ln for ln in text.splitlines() if ln.startswith("scanned "))
+    assert "2 calls · 1 errors (50.0% of calls scoped to since 2026-07-05)" in header
+    assert "all matched calls" not in header
+
+
 def test_per_scope_rates_use_that_scopes_own_denominator(tmp_path):
     """Every per-scope rate divides by THAT scope's calls — never the global count."""
     root = str(tmp_path)
@@ -1091,6 +1166,69 @@ def test_matrix_aligns_columns_for_long_fingerprint_labels(tmp_path):
             f"column {i} ({fp}) count is not right-aligned under its header label"
         )
 
+
+def test_matrix_scopes_sort_versions_naturally_not_lexicographically(tmp_path):
+    """A plain string sort puts "0.10.0" and "0.11.0" BEFORE "0.9.0" — backwards for
+    the one thing this feature exists to show: a trajectory toward the newest release.
+    UNKNOWN must still sort last regardless.
+    """
+    root = str(tmp_path)
+    versions = ["0.9.0", "0.10.0", "0.11.0", "1.0.0"]
+    records = []
+    for i, v in enumerate(versions):
+        records.append(tool_use(f"t{i}", "mcp__srv__go", {}, f"2026-07-0{i + 1}T00:00:00Z"))
+        records.append(
+            tool_result(f"t{i}", _versioned_error("code", v), f"2026-07-0{i + 1}T00:00:01Z", True)
+        )
+    # one unattributed call, to confirm "unknown" still sorts last
+    records.append(tool_use("tu", "mcp__srv__go", {}, "2026-07-05T00:00:00Z"))
+    records.append(tool_result("tu", envelope("code"), "2026-07-05T00:00:01Z", True))
+    write_jsonl(os.path.join(root, "proj", "s1.jsonl"), records)
+
+    result = mea.audit(root, "srv", 3)
+    assert mea.matrix_scopes(result) == ["0.9.0", "0.10.0", "0.11.0", "1.0.0", "unknown"]
+
+    header_row = next(
+        ln for ln in mea.to_text(result).splitlines() if ln.startswith("code ")
+    )
+    assert header_row.split() == ["code", "0.9.0", "0.10.0", "0.11.0", "1.0.0", "unknown"]
+
+
+def test_matrix_scopes_sort_fingerprints_naturally(tmp_path):
+    """Same defect, fingerprint side: "schema-10" must not sort before "schema-2"."""
+    root = str(tmp_path)
+    fps = ["schema-3", "schema-10", "schema-2"]
+    records = []
+    for i, fp in enumerate(fps):
+        body = json.dumps(
+            {
+                "ok": False,
+                "error": {"code": "code", "message": "b", "retryable": False},
+                "meta": {"fingerprint": fp},
+            }
+        )
+        records.append(tool_use(f"t{i}", "mcp__srv__go", {}, f"2026-07-0{i + 1}T00:00:00Z"))
+        records.append(tool_result(f"t{i}", body, f"2026-07-0{i + 1}T00:00:01Z", True))
+    write_jsonl(os.path.join(root, "proj", "s1.jsonl"), records)
+
+    result = mea.audit(root, "srv", 3, mea.Filters(group_by="fingerprint"))
+    assert mea.matrix_scopes(result) == ["schema-2", "schema-3", "schema-10"]
+
+
+def test_natural_sort_key_helper():
+    """Pin the helper directly: numeric runs compare by value, not lexicographically,
+    and mixed text/number chunks never raise (str and int are never compared directly).
+    """
+    versions = ["1.0.0", "0.10.0", "0.9.0", "0.2.0"]
+    assert sorted(versions, key=mea.natural_sort_key) == [
+        "0.2.0", "0.9.0", "0.10.0", "1.0.0",
+    ]
+    fps = ["schema-10", "schema-2", "schema-3"]
+    assert sorted(fps, key=mea.natural_sort_key) == ["schema-2", "schema-3", "schema-10"]
+    # No crash comparing a purely numeric scope against a purely textual one — chunks
+    # are tagged (text, number) so cross-type chunks are never compared directly.
+    # (matrix_scopes(), not this helper, is what pins UNKNOWN to sort last.)
+    assert sorted(["10", "2"], key=mea.natural_sort_key) == ["2", "10"]
 
 
 # --- CLI / slash-command argument passing -----------------------------------

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -277,3 +277,51 @@ def test_matching_is_case_insensitive(tmp_path):
     result = mea.audit(root, "SRV", 3)
     assert result["matched_servers"] == ["srv"]
     assert sum(result["total_calls"].values()) == 6
+
+
+# --- version / fingerprint extraction ---------------------------------------
+
+
+def test_extract_version_precedence():
+    # meta.server_version wins over every other shape
+    obj = {
+        "meta": {"server_version": "0.10.0", "server": {"version": "9.9.9"}},
+        "server_version": "8.8.8",
+        "server": {"version": "7.7.7"},
+    }
+    assert mea.extract_version(obj) == "0.10.0"
+    # top-level server_version is next (46% of real results carry no `meta`)
+    assert mea.extract_version({"server_version": "0.9.0"}) == "0.9.0"
+    # then the nested object forms
+    assert mea.extract_version({"meta": {"server": {"version": "0.8.0"}}}) == "0.8.0"
+    assert mea.extract_version({"server": {"version": "0.7.0"}}) == "0.7.0"
+    assert mea.extract_version({}) is None
+
+
+def test_extract_version_ignores_unrelated_version_keys():
+    """Negative control: the regex trap.
+
+    codex-in-claude emits `codex_version` — the version of the Codex CLI it shells
+    out to, NOT its own. A heuristic matching version-ish key names would report on
+    the wrong software. Extraction must be exact-path only.
+    """
+    obj = {
+        "codex_version": "codex-cli 0.144.1",
+        "cache_client_version": "0.144.1",
+        "version_supported": True,
+        "meta": {"fingerprint": "srv/0.1/schema-38"},
+    }
+    assert mea.extract_version(obj) is None
+
+
+def test_extract_fingerprint_both_shapes():
+    assert mea.extract_fingerprint({"meta": {"fingerprint": "a/1"}}) == "a/1"
+    assert mea.extract_fingerprint({"fingerprint": "b/2"}) == "b/2"
+    assert mea.extract_fingerprint({"meta": {"fingerprint": "a/1"}, "fingerprint": "b/2"}) == "a/1"
+    assert mea.extract_fingerprint({}) is None
+
+
+def test_extract_rejects_non_string_and_empty():
+    assert mea.extract_version({"server_version": ""}) is None
+    assert mea.extract_version({"server_version": 10}) is None
+    assert mea.extract_version({"meta": "not-a-dict"}) is None

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -718,6 +718,9 @@ def test_date_filter_excludes_undated_calls_without_filing_it_as_unattributed(tm
     text = mea.to_text(result)
     assert "PARTIAL" not in text
     assert "1 calls with no timestamp" in text
+    # Verify the JSON output carries the excluded_missing_timestamp key.
+    data = json.loads(mea.to_json(result))
+    assert data["coverage"]["excluded_missing_timestamp"] == 1
 
 
 def _fingerprint_only_corpus(root):
@@ -955,6 +958,8 @@ def test_header_rate_label_matches_denominator_under_unknown_only(tmp_path):
     header = next(ln for ln in text.splitlines() if ln.startswith("scanned "))
     assert "3 calls · 1 errors (33.3% of calls scoped to unknown=only)" in header
     assert "all matched calls" not in header
+    # Pin the PARTIAL note's closing sentence: it must name the scoped denominator.
+    assert "header spans calls scoped to unknown=only." in text
 
 
 def test_header_rate_label_matches_denominator_under_date_scope(tmp_path):
@@ -1228,7 +1233,7 @@ def test_natural_sort_key_helper():
     # No crash comparing a purely numeric scope against a purely textual one — chunks
     # are tagged (text, number) so cross-type chunks are never compared directly.
     # (matrix_scopes(), not this helper, is what pins UNKNOWN to sort last.)
-    assert sorted(["10", "2"], key=mea.natural_sort_key) == ["2", "10"]
+    assert sorted(["v2.0", "1.0.0"], key=mea.natural_sort_key) == ["v2.0", "1.0.0"]
 
 
 # --- CLI / slash-command argument passing -----------------------------------

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -203,7 +203,12 @@ def test_samples_are_recent_dated_and_carry_inputs(tmp_path):
     result = mea.audit(root, "srv", 3)
     stat = result["codes"]["not_found"]
     assert stat.count == 5
-    assert stat.recovered == 1
+    # This fixture's envelopes carry NO version, so every call's scope is `unknown`.
+    # This assertion previously read `stat.recovered == 1` — it encoded the bug that
+    # unknown == unknown counts as a same-release recovery. Two calls that each carry
+    # no version may be from different releases; the honest answer is indeterminate.
+    assert stat.recovered == 0
+    assert stat.cross_version_success == 1
     assert stat.first_seen.startswith("2026-06-01")
     assert stat.last_seen.startswith("2026-07-04")
     # 5 errors, limit 3 → the 3 most recent survive
@@ -496,6 +501,76 @@ def test_recovery_counts_within_the_same_version(tmp_path):
     stat = mea.audit(root, "srv", 3)["codes"]["boom_code"]
     assert stat.recovered == 1
     assert stat.cross_version_success == 0
+
+
+def _pair(root, err_body, ok_body):
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            tool_result("t1", err_body, "2026-07-01T00:00:01Z", True),
+            tool_use("t2", "mcp__srv__go", {}, "2026-07-01T00:01:00Z"),
+            tool_result("t2", ok_body, "2026-07-01T00:01:01Z"),
+        ],
+    )
+
+
+def test_a_success_at_an_unknown_scope_is_never_recovery(tmp_path):
+    """The spec: "A later success at a different OR UNKNOWN scope does not count as
+    recovery." aggregate() compared pend_scope == scope, so two calls that BOTH carry no
+    version compared equal — unknown == unknown — and the success was credited as a
+    same-release recovery.
+
+    Since nothing stamps a version yet, EVERY call today is version-unknown: scope-aware
+    recovery was inert by default, `recov` silently reverted to the old unscoped
+    semantics, and `cross` read a reassuring 0.
+    """
+    unknown_err = envelope("boom_code")  # well-formed envelope, no version
+    unknown_ok = json.dumps({"ok": True})
+
+    # unknown → unknown: NOT a recovery. Both calls could be from different releases.
+    root = str(tmp_path / "uu")
+    _pair(root, unknown_err, unknown_ok)
+    stat = mea.audit(root, "srv", 3)["codes"]["boom_code"]
+    assert stat.recovered == 0
+    assert stat.cross_version_success == 1
+
+    # known error → unknown success: the success proves nothing about 1.0.0.
+    root = str(tmp_path / "ku")
+    _pair(root, _versioned_error("boom_code", "1.0.0"), unknown_ok)
+    stat = mea.audit(root, "srv", 3)["codes"]["boom_code"]
+    assert stat.recovered == 0
+    assert stat.cross_version_success == 1
+
+    # unknown error → known success: the error is not "recovered" by anything.
+    root = str(tmp_path / "uk")
+    _pair(root, unknown_err, _versioned_ok("1.0.0"))
+    stat = mea.audit(root, "srv", 3)["codes"]["boom_code"]
+    assert stat.recovered == 0
+    assert stat.cross_version_success == 1
+
+    # POSITIVE CONTROL: recovery is still reachable — an attributed scope recovers itself.
+    # (Otherwise `recovered == 0` above would be indistinguishable from a dead counter.)
+    root = str(tmp_path / "kk")
+    _pair(root, _versioned_error("boom_code", "1.0.0"), _versioned_ok("1.0.0"))
+    stat = mea.audit(root, "srv", 3)["codes"]["boom_code"]
+    assert stat.recovered == 1
+    assert stat.cross_version_success == 0
+
+    # And under --group-by fingerprint, a fingerprinted corpus recovers normally: the
+    # rule is about UNATTRIBUTED scopes, not about versions specifically.
+    root = str(tmp_path / "fp")
+    fp_err = json.dumps(
+        {"ok": False, "error": {"code": "boom_code", "message": "b", "retryable": False},
+         "meta": {"fingerprint": "srv/0.1/schema-38"}}
+    )
+    fp_ok = json.dumps({"ok": True, "meta": {"fingerprint": "srv/0.1/schema-38"}})
+    _pair(root, fp_err, fp_ok)
+    by_fp = mea.audit(root, "srv", 3, mea.Filters(group_by="fingerprint"))["codes"]["boom_code"]
+    assert by_fp.recovered == 1
+    by_ver = mea.audit(root, "srv", 3, mea.Filters(group_by="version"))["codes"]["boom_code"]
+    assert by_ver.recovered == 0  # same corpus, no version: indeterminate
+    assert by_ver.cross_version_success == 1
 
 
 def test_multi_version_folded_session_attributes_each_call(tmp_path):

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -647,6 +647,55 @@ def test_unknown_only_and_exclude(tmp_path):
 # --- coverage and the matrix ------------------------------------------------
 
 
+def test_coverage_attribution_is_dimension_aware(tmp_path):
+    """Coverage attribution must be relative to the ACTIVE group_by dimension.
+
+    A call whose envelope carries only a fingerprint (no server_version) is a
+    perfectly well-formed result — but it is NOT attributed under
+    group_by='version', even though rec.unknown_reason is None (an envelope was
+    present). Regression for: the text report claimed calls were "attributed to
+    a version" while the by-version matrix showed every one of them at scope
+    'unknown' — an outright contradiction. Real-corpus shape: servers that only
+    ever emit a fingerprint, never a server_version.
+    """
+    root = str(tmp_path)
+    fp_only = json.dumps(
+        {
+            "ok": False,
+            "error": {"code": "fp_code", "message": "b", "retryable": False},
+            "meta": {"fingerprint": "srv/0.1/schema-38"},
+        }
+    )
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            tool_result("t1", fp_only, "2026-07-01T00:00:01Z", True),
+            tool_use("t2", "mcp__srv__go", {}, "2026-07-01T00:01:00Z"),
+            tool_result("t2", fp_only, "2026-07-01T00:01:01Z", True),
+        ],
+    )
+
+    by_version = mea.audit(root, "srv", 3, mea.Filters(group_by="version"))
+    cov_v = by_version["coverage"]
+    assert cov_v.attributed_calls == 0
+    assert cov_v.unknown == {"not_emitted": 2}
+    assert cov_v.total_calls == cov_v.attributed_calls + sum(cov_v.unknown.values())
+    # The matrix must AGREE with coverage: every call's version-scope is unknown.
+    assert sorted({sc for s in by_version["codes"].values() for sc in s.by_scope}) == [
+        "unknown"
+    ]
+
+    by_fp = mea.audit(root, "srv", 3, mea.Filters(group_by="fingerprint"))
+    cov_fp = by_fp["coverage"]
+    assert cov_fp.attributed_calls == 2
+    assert cov_fp.unknown == {}
+    assert cov_fp.total_calls == cov_fp.attributed_calls + sum(cov_fp.unknown.values())
+    assert sorted(
+        {sc for s in by_fp["codes"].values() for sc in s.by_scope}
+    ) == ["srv/0.1/schema-38"]
+
+
 def test_rate_uses_attributed_calls_and_flags_partial(tmp_path):
     root = str(tmp_path)
     write_jsonl(
@@ -801,3 +850,49 @@ def test_discovery_output_is_unchanged_by_version_work(tmp_path):
     assert data["servers"]["srv"]["errors"] == 2
     assert data["servers"]["srv"]["error_rate"] == 1.0
     assert "coverage" not in data
+
+
+# --- "no calls matched" message must distinguish its two causes -------------
+
+
+def test_no_such_server_message_unchanged(tmp_path):
+    """Genuinely no such server: the original, unqualified message."""
+    root = str(tmp_path)
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            tool_result("t1", _versioned_error("boom", "1.0.0"), "2026-07-01T00:00:01Z", True),
+        ],
+    )
+    result = mea.audit(root, "nosuchserver", 3)
+    text = mea.to_text(result)
+    assert (
+        "No MCP tool calls matched. Run without --server to list "
+        "the servers seen in transcripts." in text
+    )
+
+
+def test_filter_excludes_everything_message_names_the_filter(tmp_path):
+    """The server matched calls; a scope filter excluded all of them. The message
+    must say so and name the filter — NOT imply the server name was wrong.
+
+    Regression for: `--server-version 0.10.0` on a corpus with no versions at all
+    printed the exact same "no such server" message as a genuinely bad server name,
+    sending the user to fix the wrong thing.
+    """
+    root = str(tmp_path)
+    write_jsonl(
+        os.path.join(root, "proj", "s1.jsonl"),
+        [
+            tool_use("t1", "mcp__srv__go", {}, "2026-07-01T00:00:00Z"),
+            tool_result("t1", _versioned_error("boom", "1.0.0"), "2026-07-01T00:00:01Z", True),
+            tool_use("t2", "mcp__srv__go", {}, "2026-07-01T00:01:00Z"),
+            tool_result("t2", _versioned_error("boom", "1.0.0"), "2026-07-01T00:01:01Z", True),
+        ],
+    )
+    result = mea.audit(root, "srv", 3, mea.Filters(server_version="9.9.9"))
+    text = mea.to_text(result)
+    assert "No MCP tool calls matched" not in text
+    assert "matched 2 calls for this server, but 0 after scoping to" in text
+    assert "server-version 9.9.9" in text

--- a/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
+++ b/plugins/mcp-error-audit/tests/test_mcp_error_audit.py
@@ -592,15 +592,37 @@ def test_date_filter_uses_the_call_timestamp_not_the_result(tmp_path):
 
 def test_date_filter_excludes_undated_calls_as_missing_timestamp(tmp_path):
     root = str(tmp_path)
-    rec_use = tool_use("t1", "mcp__srv__go", {}, "2026-07-05T00:00:00Z")
-    del rec_use["timestamp"]  # an undated call cannot be placed in a window
-    write_jsonl(
-        os.path.join(root, "proj", "s1.jsonl"),
-        [rec_use, tool_result("t1", _versioned_error("c", "1.0.0"), "2026-07-05T00:00:01Z", True)],
-    )
+    # Build a corpus with both dated and undated calls inside the window
+    records = [
+        # dated call inside the window
+        tool_use("t1", "mcp__srv__go", {}, "2026-07-05T00:00:00Z"),
+        tool_result("t1", _versioned_error("dated_error", "1.0.0"), "2026-07-05T00:00:01Z", True),
+        # dated call inside the window that succeeds
+        tool_use("t2", "mcp__srv__go", {}, "2026-07-05T10:00:00Z"),
+        tool_result("t2", _versioned_ok("1.0.0"), "2026-07-05T10:00:01Z"),
+    ]
+    # undated call cannot be placed in a window
+    rec_use = tool_use("t3", "mcp__srv__go", {}, "2026-07-05T12:00:00Z")
+    del rec_use["timestamp"]
+    records.extend([rec_use, tool_result("t3", _versioned_error("undated_error", "1.0.0"), "2026-07-05T12:00:01Z", True)])
+
+    write_jsonl(os.path.join(root, "proj", "s1.jsonl"), records)
     result = mea.audit(root, "srv", 3, mea.Filters(since="2026-07-05"))
-    assert set(result["codes"]) == set()
-    assert result["coverage"].unknown["missing_timestamp"] == 1
+
+    # Verify the invariant: total_calls == attributed_calls + sum(unknown.values())
+    cov = result["coverage"]
+    assert cov.total_calls == cov.attributed_calls + sum(cov.unknown.values()), \
+        f"Invariant broken: {cov.total_calls} != {cov.attributed_calls} + {sum(cov.unknown.values())}"
+
+    # Verify the undated call is excluded but still counted in total_calls
+    assert cov.unknown["missing_timestamp"] == 1
+    assert cov.total_calls == 3  # 2 dated + 1 undated
+
+    # Verify the dated calls are still counted and attributed
+    assert cov.attributed_calls == 2  # only dated calls have versions
+
+    # Verify the error from the dated call is in the codes (undated error is excluded)
+    assert set(result["codes"]) == {"dated_error"}
 
 
 def test_unknown_only_and_exclude(tmp_path):


### PR DESCRIPTION
## What

Lets `/mcp-error-audit` scope an audit to a particular **release** of the audited MCP server, so you can ask "what is still broken in the version I am running now?" instead of guessing from `first_seen`/`last_seen` dates.

New flags, honestly labeled by what they actually are:

| flag | basis | honesty |
| --- | --- | --- |
| `--server-version 0.10.0` | stamped in the result envelope | **observed** |
| `--fingerprint schema-37` | already in the envelope today | **observed** |
| `--since` / `--until` | record timestamps | **approximate** — a date is only a proxy for a release |

Plus `--group-by version\|fingerprint`, `--unknown include\|exclude\|only`, and a **code × release matrix**.

## The governing rule

**Never report a statistic whose denominator is a guess.**

- Attribution is read *only* from a call's own paired `tool_result`, via an **exact-path allowlist** — never a regex over key names. (`codex-in-claude` emits `codex_version`, which is the *Codex CLI's* version, not its own; a name-matching heuristic would report on the wrong software. There is a negative-control test for exactly this.)
- Attribution is **dimension-aware**: a call carrying only a fingerprint is *not* attributed to a *version*.
- Attribution ⊥ classification: a result with no envelope is unattributable but may still be a **real error** (transport drops, `tool_unavailable`), and stays in the error totals.
- Rates are `errors / attributed calls`, and every label names the denominator it actually divides by.
- Absence is reported as **absence of evidence** — "not observed in 0.10.0 over N attributed calls", never "fixed". The tool reads transcripts; it cannot see a code change.
- A release with **zero errors still gets a matrix column**, because columns are derived from *call* scopes, not error scopes.

Recovery is scope-aware: a success on a *different or unknown* release does not count as recovering an error from an earlier one — that is the environment changing, not the failure being fixed. It reports as indeterminate.

## Also fixed

The slash command previously interpolated all of `$ARGUMENTS` into `--server`, so **every flag was unreachable** (`VALID_SERVER` rejected the space). It now parses a server token plus flags.

## Known, accepted risk

The command interpolates `$ARGUMENTS` into a shell string and **is injectable** (`x' ; echo pwned #`). This is **pre-existing** — the original command had the identical shape — and is documented rather than fixed. The Python-side quote check does *not* prevent it (bash tokenizes before Python runs), and the code comment and README now say so plainly instead of claiming a protection that does not hold.

## Verification

23 commits, 60 tests. Behavior verified against the real transcript corpus, not just fixtures. The final review swept **216 flag combinations** with an independent oracle (0 failures; the same probe against the pre-fix commit produced 458, confirming the instrument works). Load-bearing tests were mutation-tested — four vacuous tests were caught and fixed during review, including one that passed with the entire matrix deleted. Discovery-mode output is byte-identical to the pre-branch baseline.

Companion change (separate repo): `codex-in-claude` will stamp `server_version` in every result envelope, which is what makes `--server-version` return data. Until then it correctly returns nothing, and the corpus is scoped by fingerprint.

🤖 Generated with Claude Code