### PR TITLE
chore(claude-in-codex): bump to 0.7.0

### DIFF
--- a/plugins/claude-in-codex/.codex-plugin/plugin.json
+++ b/plugins/claude-in-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-in-codex",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Call Claude Code from Codex for bounded, independent code review and second opinions",
   "author": { "name": "Brian Connelly", "url": "https://github.com/briandconnelly" },
   "repository": "https://github.com/briandconnelly/claude-in-codex",

--- a/plugins/claude-in-codex/.mcp.json
+++ b/plugins/claude-in-codex/.mcp.json
@@ -4,7 +4,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "claude-in-codex==0.6.0",
+        "claude-in-codex==0.7.0",
         "claude-in-codex-mcp"
       ],
       "env_vars": [


### PR DESCRIPTION
Bumps `claude-in-codex` from 0.6.0 to 0.7.0 in `.codex-plugin/plugin.json` and the PyPI pin in `.mcp.json`.

## Upstream changes in 0.7.0

- New `claude_models` tool and canonical `claude-in-codex://models` resource (free, read-only catalog of accepted `model` slugs); `claude://models` is a deprecated alias.
- `idempotency_key` on `claude_review_changes_async` — a duplicate launch within the job TTL returns the existing job instead of spending again.
- Best-effort secret redaction extended to Claude's returned output, not just gathered diff lines.
- Argument-validation failures now return the standard `ok:false` envelope (`invalid_arguments`) with structured repair fields.
- Hardened background-job persistence and lifecycle handling; contract fingerprint now `claude-in-codex/0.1/schema-27`.

## Verification

- `claude-in-codex==0.7.0` is published on PyPI, so the pin resolves.
- No other `0.6.0` references remain in the plugin; `marketplace.json` and the README table carry no versions per repo convention.
- `.codex-plugin/plugin.json` and `skills/collaborating-with-claude/SKILL.md` are byte-identical to upstream tag `v0.7.0` (upstream HEAD). The only intentional divergence is `.mcp.json` using the PyPI pin instead of upstream's `git+https://…@v0.7.0`, matching 04a0d54.

## Known gap (upstream, not blocking)

Upstream's own skill does not document `claude_models`, `claude-in-codex://models`, or `idempotency_key`, and still describes redaction as diff-only. Filed as briandconnelly/claude-in-codex#79 rather than patching the copy here, which would fork the file.

🤖 Generated with Claude Code